### PR TITLE
fix(docker): switch from Amazon Corretto to Eclipse Temurin 21 JRE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:25-jre
+FROM eclipse-temurin:21-jre
 
 # Create non-root user for security
 RUN groupadd -r nextskip && useradd -r -g nextskip nextskip


### PR DESCRIPTION
## Summary

Fixes the Docker build workflow by replacing the Amazon Corretto 25 JRE base image with Eclipse Temurin 21 JRE.

**Changes:**
- Updated `Dockerfile` base image from `amazoncorretto:25-jre` to `eclipse-temurin:21-jre`

**Rationale:**
- Aligns with Java 21 bytecode target defined in `build.gradle`
- Matches the Temurin distribution used in the CI workflow (`.github/workflows/ci.yml`)
- The Temurin image is Debian-based, maintaining compatibility with existing user management commands and curl healthcheck

## Test plan

- [ ] Verify Docker build succeeds in CI workflow
- [ ] Verify Docker image runs successfully
- [ ] Verify healthcheck endpoint responds correctly