### PR TITLE
build(docker): Add multi-stage build with distroless runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,20 +6,17 @@
 # CI/CD
 .github
 
-# Build artifacts (except the JAR we need)
-build/*
-!build/libs/*.jar
-.gradle
-gradle
+# Build output (will be created during build)
+build/
+.gradle/
+target/
 
-# Node/Frontend
-node_modules
-frontend/tests
-coverage
+# Node modules (npm install runs during build)
+node_modules/
 
 # IDE
-.idea
-.vscode
+.idea/
+.vscode/
 *.iml
 *.iws
 *.ipr
@@ -28,11 +25,14 @@ coverage
 .DS_Store
 Thumbs.db
 
-# Documentation
-*.md
-docs
-
-# Test and config files
-src/test
+# Development config
+.claude/
 .tool-versions
-.claude
+*.md
+!README.md
+
+# Test artifacts (not needed for production build)
+src/test/e2e/
+playwright-report/
+test-results/
+coverage/


### PR DESCRIPTION
## Summary
- Converts Dockerfile to multi-stage build that builds from source
- Uses Google Distroless Java 25 runtime for minimal, secure deployment
- No longer requires pre-built JAR

## Changes

### Dockerfile
- **Build stage**: `eclipse-temurin:25-jdk` with Node.js 24.x
  - Builds Spring Boot JAR and Vaadin Hilla frontend from source
  - Optimized layer caching (Gradle deps before source code)
- **Runtime stage**: `gcr.io/distroless/java25-debian13`
  - Minimal attack surface (no shell, no package managers)
  - Runs as non-root user (uid 65532)
  - Final image: 321MB

### .dockerignore
- Updated to allow source files for building
- Excludes build artifacts, node_modules, and test files

## Testing
- ✅ Local Docker build successful
- ✅ Application starts in 2.1 seconds
- ✅ Health check endpoint verified

## Notes
- CI/CD workflow still compatible (pre-built JAR works but is optional)
- Distroless has no curl, so HEALTHCHECK removed (rely on orchestrator health checks)