### PR TITLE
ci(dependabot): increase open PR limit to 20 per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,27 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 20
+    ignore:
+      # Hilla packages are controlled by Vaadin Gradle plugin version
+      # They are locked to the Vaadin BOM version via vaadinPrepareFrontend task
+      - dependency-name: "@vaadin/hilla-*"
+      - dependency-name: "@vaadin/hilla-generator-*"


### PR DESCRIPTION
## Summary

Optimizes Dependabot configuration based on how Vaadin/Hilla dependency management works.

## Changes

### Increased PR Limits
Set `open-pull-requests-limit: 20` for all ecosystems:
- `github-actions`
- `docker`
- `gradle`
- `npm`

### Excluded Hilla Packages from npm Scanning
Added ignore rules for packages controlled by the Vaadin Gradle plugin:
- `@vaadin/hilla-*` (all Hilla runtime packages)
- `@vaadin/hilla-generator-*` (all Hilla generator packages)

## Rationale

### Why Increase PR Limits?
The default limit of 5 open PRs per ecosystem can throttle dependency updates. Raising to the maximum (20) allows Dependabot to create more concurrent PRs when multiple packages need upgrading.

**New capacity:** Up to 80 total concurrent PRs (20 × 4 ecosystems)

### Why Exclude Hilla Packages?
Through testing Vaadin 25.0.0 → 25.0.1 upgrade, we discovered that:

**Controlled by Vaadin Gradle Plugin** (always reverted):
- All `@vaadin/hilla-*` packages are locked to the Vaadin BOM version
- The `vaadinPrepareFrontend` Gradle task overwrites these versions to match `vaadinVersion` in build.gradle
- Any Dependabot PRs for these packages would be reverted on next build

**Not Controlled** (can upgrade independently):
- `@vaadin/aura`, `@vaadin/react-components`
- Web component packages (`@vaadin/button`, `@vaadin/grid`, etc.)
- Non-Vaadin dependencies

**Benefits of excluding:**
- ✅ Reduces noise from PRs that will be automatically reverted
- ✅ Prevents accidental merges of non-actionable updates
- ✅ Focuses attention on packages we can actually upgrade
- ✅ Saves CI resources

Hilla packages are upgraded by updating `vaadinVersion` in build.gradle, not through npm.

## Test Plan

- [x] Validate YAML syntax
- [ ] Monitor Dependabot behavior after merge
- [ ] Confirm no Hilla package PRs are created
- [ ] Confirm web component and non-Vaadin PRs still work