### PR TITLE
build(deps): enable Renovate detection for quality tools

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,10 +12,15 @@
       "enabled": false
     },
     {
-      "description": "Checkstyle - group all versions into single PR",
+      "description": "Quality tools - group all updates into single PR",
       "matchManagers": ["gradle"],
-      "matchPackageNames": ["com.puppycrawl.tools:checkstyle"],
-      "groupName": "checkstyle",
+      "matchPackageNames": [
+        "com.puppycrawl.tools:checkstyle",
+        "net.sourceforge.pmd:pmd-java",
+        "com.github.spotbugs:spotbugs",
+        "org.jacoco:jacoco"
+      ],
+      "groupName": "quality-tools",
       "separateMajorMinor": false,
       "separateMinorPatch": false
     },

--- a/build.gradle
+++ b/build.gradle
@@ -149,21 +149,25 @@ configurations.all {
 
 // Code quality plugin configurations
 
+// NOTE: Using direct string literals instead of version catalog accessors (libs.versions.X.get())
+// to enable Renovate detection until native support is added.
+// See: https://github.com/renovatebot/renovate/discussions/40147
+// Can be reverted to catalog accessors if Renovate adds native support.
 checkstyle {
-    toolVersion = libs.versions.checkstyle.get()
+    toolVersion = "10.12.5"
     configFile = file("${rootDir}/config/checkstyle/checkstyle.xml")
     ignoreFailures = true  // Report violations but don't fail build during development
 }
 
 pmd {
-    toolVersion = libs.versions.pmd.get()
+    toolVersion = "7.9.0"
     ruleSets = []  // Empty to use custom ruleset file
     ruleSetFiles = files("${rootDir}/config/pmd/ruleset.xml")
     ignoreFailures = true  // Report violations but don't fail build during development
 }
 
 spotbugs {
-    toolVersion = libs.versions.spotbugs.tool.get()
+    toolVersion = "4.8.6"
     effort = 'max'
     reportLevel = 'medium'
     ignoreFailures = true  // Report violations but don't fail build during development
@@ -177,7 +181,7 @@ tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
 }
 
 jacoco {
-    toolVersion = libs.versions.jacoco.get()
+    toolVersion = "0.8.14"
 }
 
 jacocoTestReport {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,12 +5,10 @@ spring-boot = "4.0.1"
 spring-dependency-management = "1.1.7"
 
 # Quality & testing tools
+# NOTE: checkstyle, pmd, spotbugs-tool, and jacoco versions moved to direct literals in build.gradle
+# to enable Renovate detection. See: https://github.com/renovatebot/renovate/discussions/40147
 spotbugs-plugin = "6.4.8"
 pitest = "1.19.0-rc.2"
-checkstyle = "10.12.5"
-pmd = "7.9.0"
-spotbugs-tool = "4.8.6"
-jacoco = "0.8.14"
 
 # Dependencies (not managed by Spring Boot BOM)
 resilience4j = "2.3.0"


### PR DESCRIPTION
## Summary

Enables Renovate to detect and update quality tool versions (Checkstyle, PMD, SpotBugs, JaCoCo) by switching from version catalog accessors to direct string literals.

## Changes

- **build.gradle**: Changed `toolVersion = libs.versions.X.get()` to direct string literals
- **gradle/libs.versions.toml**: Removed unused version entries for quality tools
- **.github/renovate.json**: Updated packageRule to group all quality tools into single PR

## Why

Renovate's Gradle parser supports `toolVersion = "7.9.0"` but not `toolVersion = libs.versions.pmd.get()`. This is a parser limitation - the method call expression cannot be resolved back to the version catalog entry.

## Temporary Solution

This is a **temporary workaround** until Renovate adds native support for version catalog accessors. See [Discussion #40147](https://github.com/renovatebot/renovate/discussions/40147) for the feature request.

These changes **can be reverted** to catalog accessors if Renovate implements native support.

## Testing

Verified with local Renovate dry-run:
- ✅ Quality tools extracted from build.gradle (30 dependencies found)
- ✅ Updates detected and grouped as "quality-tools"
- ✅ Renovate attempted to create update branch

## Current Versions

- Checkstyle: 10.12.5
- PMD: 7.9.0
- SpotBugs: 4.8.6
- JaCoCo: 0.8.14

Renovate will now automatically detect when newer versions are available.