### PR TITLE
ci(workflows): add explicit permissions to all jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -24,6 +26,9 @@ jobs:
   backend-test:
     needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -72,6 +77,9 @@ jobs:
   frontend-test:
     needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -113,6 +121,8 @@ jobs:
   build-jar:
     needs: [backend-test, frontend-test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -155,6 +165,8 @@ jobs:
     needs: build-jar
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to all GitHub Actions jobs following least-privilege principle
- Addresses 6 open code scanning alerts (`actions/missing-workflow-permissions`)

## Changes

### `.github/workflows/ci.yml`
| Job | Permissions Added |
|-----|-------------------|
| `validate` | `contents: read` |
| `backend-test` | `contents: read`, `checks: write` |
| `frontend-test` | `contents: read`, `security-events: write` |
| `build-jar` | `contents: read` |
| `e2e-test` | `contents: read` |

### `.github/workflows/renovate.yml`
| Job | Permissions Added |
|-----|-------------------|
| `renovate` | `contents: read` |

## Test plan
- [ ] CI pipeline passes
- [ ] Code scanning alerts are resolved after merge

Fixes: https://github.com/arunderwood/nextskip/security/code-scanning/12, https://github.com/arunderwood/nextskip/security/code-scanning/13, https://github.com/arunderwood/nextskip/security/code-scanning/14, https://github.com/arunderwood/nextskip/security/code-scanning/15, https://github.com/arunderwood/nextskip/security/code-scanning/16, https://github.com/arunderwood/nextskip/security/code-scanning/17