### PR TITLE
feat(observability): add Grafana OpenTelemetry Java agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,9 @@ FROM gcr.io/distroless/java25-debian13
 
 WORKDIR /app
 
-# Copy the built JAR from builder stage
+# Copy the built JAR and OTEL agent from builder stage
 COPY --from=builder /app/build/libs/*.jar app.jar
+COPY --from=builder /app/build/otel-agent/grafana-opentelemetry-java.jar otel-agent.jar
 
 # Distroless runs as non-root by default (uid 65532)
 # Spring Boot optimizations via JAVA_TOOL_OPTIONS (distroless doesn't support JAVA_OPTS)
@@ -38,5 +39,5 @@ ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
 EXPOSE 8080
 
 # Distroless has no shell, so use exec form
-# Note: Health checks won't work in distroless (no curl), rely on orchestrator health checks
-ENTRYPOINT ["java", "-jar", "app.jar"]
+# Agent enabled by default; disable with OTEL_JAVAAGENT_ENABLED=false
+ENTRYPOINT ["java", "-javaagent:/app/otel-agent.jar", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ tasks.named('jar') {
 // The vaadinBuildFrontend task writes to build/resources/main/ AFTER processResources,
 // so we need to explicitly include these files in the bootJar
 tasks.named('bootJar') {
-    dependsOn 'vaadinBuildFrontend'
+    dependsOn 'vaadinBuildFrontend', 'downloadOtelAgent'
 
     // Explicitly copy Vaadin production files into the JAR
     into('BOOT-INF/classes') {
@@ -123,6 +123,27 @@ dependencies {
     // Java 25 compatibility - override Mockito and ByteBuddy
     testImplementation libs.mockito.core
     testImplementation libs.byte.buddy
+}
+
+// OpenTelemetry agent configuration
+def otelAgentVersion = libs.versions.grafana.otel.agent.get()
+def otelAgentDir = layout.buildDirectory.dir("otel-agent")
+def otelAgentJar = otelAgentDir.map { it.file("grafana-opentelemetry-java.jar") }
+
+tasks.register('downloadOtelAgent') {
+    description = 'Downloads the Grafana OpenTelemetry Java agent'
+    group = 'observability'
+
+    outputs.file(otelAgentJar)
+
+    doLast {
+        def agentUrl = "https://github.com/grafana/grafana-opentelemetry-java/releases/download/v${otelAgentVersion}/grafana-opentelemetry-java.jar"
+        def destFile = otelAgentJar.get().asFile
+        destFile.parentFile.mkdirs()
+
+        ant.get(src: agentUrl, dest: destFile, skipexisting: false)
+        println "Downloaded Grafana OTEL agent v${otelAgentVersion} to ${destFile}"
+    }
 }
 
 tasks.named('test') {

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,18 @@
+# Observability
+
+Auto-instrumented via [Grafana OTEL Java agent](https://grafana.com/docs/opentelemetry/instrument/grafana-java/).
+
+## Configuration
+
+Get credentials: [Grafana Cloud Portal](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/) → Your Stack → OpenTelemetry → Configure
+
+| Variable                      | Value                               |
+| ----------------------------- | ----------------------------------- |
+| `OTEL_SERVICE_NAME`           | `nextskip`                          |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `<from portal>`                     |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf`                     |
+| `OTEL_EXPORTER_OTLP_HEADERS`  | `Authorization=Basic <from portal>` |
+
+Disable agent: `OTEL_JAVAAGENT_ENABLED=false`
+
+Agent version: `gradle/libs.versions.toml` → `grafana-otel-agent`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,9 @@ vaadin = "25.0.2"
 spring-boot = "4.0.1"
 spring-dependency-management = "1.1.7"
 
+# Observability
+grafana-otel-agent = "2.22.0"
+
 # Quality & testing tools
 # NOTE: checkstyle, pmd, spotbugs-tool, and jacoco versions moved to direct literals in build.gradle
 # to enable Renovate detection. See: https://github.com/renovatebot/renovate/discussions/40147


### PR DESCRIPTION
## Summary

- Adds Grafana OpenTelemetry Java agent for auto-instrumentation (traces, metrics, logs)
- Agent version managed in `gradle/libs.versions.toml` (Renovate-compatible)
- Gradle task downloads agent during `bootJar` build
- Docker image includes agent with `-javaagent` entrypoint
- Agent can be disabled at runtime via `OTEL_JAVAAGENT_ENABLED=false`

## Configuration

See `docs/OBSERVABILITY.md` for Grafana Cloud setup.

## Test plan

- [x] `./gradlew downloadOtelAgent` downloads agent to `build/otel-agent/`
- [ ] `docker build` includes agent in image
- [ ] Container starts with agent (check logs for OTEL initialization)
- [ ] Disable test: `OTEL_JAVAAGENT_ENABLED=false` skips agent loading