### PR TITLE
build(renovate): add custom manager for Grafana OTEL agent

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,16 @@
   "prHourlyLimit": 0,
   "recreateWhen": "always",
   "labels": ["dependencies"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Grafana OTEL Java agent from GitHub releases",
+      "managerFilePatterns": ["/gradle/libs\\.versions\\.toml$/"],
+      "matchStrings": ["grafana-otel-agent\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "grafana/grafana-opentelemetry-java",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
   "packageRules": [
     {
       "description": "Docker - disable all updates (manually managed)",


### PR DESCRIPTION
## Summary

Adds a custom regex manager to Renovate so it can detect and update the `grafana-otel-agent` version in `gradle/libs.versions.toml`.

Without this, Renovate won't detect the version because it's not a Maven dependency - it's used to construct a GitHub release download URL.

## Configuration

```json
{
  "customType": "regex",
  "managerFilePatterns": ["/gradle/libs\\.versions\\.toml$/"],
  "matchStrings": ["grafana-otel-agent\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
  "depNameTemplate": "grafana/grafana-opentelemetry-java",
  "datasourceTemplate": "github-releases"
}
```

## Test plan

- [x] `npx renovate-config-validator .github/renovate.json` passes
- [x] Regex matches `grafana-otel-agent = "2.22.0"` in version catalog
- [ ] Renovate proposes update when new release is available