### PR TITLE
fix(cache): resolve immediate caching issues causing API calls on every page load

### DIFF
--- a/src/main/java/io/nextskip/activations/internal/PotaClient.java
+++ b/src/main/java/io/nextskip/activations/internal/PotaClient.java
@@ -76,7 +76,7 @@ public class PotaClient implements ExternalDataClient<List<Activation>> {
     @Override
     @CircuitBreaker(name = "pota", fallbackMethod = "getCachedActivations")
     @Retry(name = "pota")
-    @Cacheable(value = "potaActivations", key = "'current'", unless = "#result == null || #result.isEmpty()")
+    @Cacheable(value = "potaActivations", key = "'current'", unless = "#result == null")
     public List<Activation> fetch() {
         LOG.debug("Fetching POTA activations from API");
 

--- a/src/main/java/io/nextskip/activations/internal/SotaClient.java
+++ b/src/main/java/io/nextskip/activations/internal/SotaClient.java
@@ -81,7 +81,7 @@ public class SotaClient implements ExternalDataClient<List<Activation>> {
     @Override
     @CircuitBreaker(name = "sota", fallbackMethod = "getCachedActivations")
     @Retry(name = "sota")
-    @Cacheable(value = "sotaActivations", key = "'current'", unless = "#result == null || #result.isEmpty()")
+    @Cacheable(value = "sotaActivations", key = "'current'", unless = "#result == null")
     public List<Activation> fetch() {
         LOG.debug("Fetching SOTA activations from API");
 

--- a/src/main/java/io/nextskip/common/config/CacheConfig.java
+++ b/src/main/java/io/nextskip/common/config/CacheConfig.java
@@ -15,7 +15,9 @@ import java.util.concurrent.TimeUnit;
  * Defines cache TTLs for different data sources:
  * - solarIndices: 5 minutes (NOAA data)
  * - bandConditions: 30 minutes (HamQSL data)
- * - activations: 60 seconds (POTA/SOTA real-time spots)
+ * - potaActivations: 2 minutes (POTA real-time spots)
+ * - sotaActivations: 2 minutes (SOTA real-time spots)
+ * - meteorShowers: 2 hours (meteor shower data)
  * - contests: 6 hours refresh (contest schedules are stable)
  * - tleData: 6 hours (Satellite TLE data)
  * - default: 10 minutes
@@ -62,6 +64,27 @@ public class CacheConfig {
             Caffeine.newBuilder()
                 .expireAfterWrite(6, TimeUnit.HOURS)
                 .maximumSize(200)
+                .recordStats()
+                .build());
+
+        cacheManager.registerCustomCache("potaActivations",
+            Caffeine.newBuilder()
+                .expireAfterWrite(2, TimeUnit.MINUTES)
+                .maximumSize(100)
+                .recordStats()
+                .build());
+
+        cacheManager.registerCustomCache("sotaActivations",
+            Caffeine.newBuilder()
+                .expireAfterWrite(2, TimeUnit.MINUTES)
+                .maximumSize(100)
+                .recordStats()
+                .build());
+
+        cacheManager.registerCustomCache("meteorShowers",
+            Caffeine.newBuilder()
+                .expireAfterWrite(2, TimeUnit.HOURS)
+                .maximumSize(50)
                 .recordStats()
                 .build());
 

--- a/src/main/java/io/nextskip/contests/internal/ContestCalendarClient.java
+++ b/src/main/java/io/nextskip/contests/internal/ContestCalendarClient.java
@@ -91,7 +91,7 @@ public class ContestCalendarClient implements ExternalDataClient<List<ContestICa
     @Override
     @CircuitBreaker(name = CACHE_NAME, fallbackMethod = "getCachedContests")
     @Retry(name = CACHE_NAME)
-    @Cacheable(value = CACHE_NAME, key = "'upcoming'", unless = "#result == null || #result.isEmpty()")
+    @Cacheable(value = CACHE_NAME, key = "'upcoming'", unless = "#result == null")
     public List<ContestICalDto> fetch() {
         LOG.debug("Fetching contests from WA7BNM iCal feed");
 

--- a/src/main/java/io/nextskip/meteors/internal/MeteorServiceImpl.java
+++ b/src/main/java/io/nextskip/meteors/internal/MeteorServiceImpl.java
@@ -31,7 +31,7 @@ public class MeteorServiceImpl implements MeteorService {
     }
 
     @Override
-    @Cacheable(value = "meteorShowers", unless = "#result.isEmpty()")
+    @Cacheable(value = "meteorShowers", unless = "#result == null")
     public List<MeteorShower> getMeteorShowers() {
         LOG.debug("Fetching meteor showers");
         List<MeteorShower> showers = dataLoader.getShowers(DEFAULT_LOOKAHEAD_DAYS);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,11 +8,6 @@ spring:
   application:
     name: nextskip
 
-  cache:
-    type: caffeine
-    caffeine:
-      spec: maximumSize=500,expireAfterWrite=10m
-
 # Resilience4j Circuit Breaker Configuration
 resilience4j:
   circuitbreaker:

--- a/src/test/java/io/nextskip/activations/internal/CacheIntegrationTest.java
+++ b/src/test/java/io/nextskip/activations/internal/CacheIntegrationTest.java
@@ -1,0 +1,152 @@
+package io.nextskip.activations.internal;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.nextskip.activations.model.Activation;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for cache behavior.
+ *
+ * <p>Verifies that @Cacheable annotations work correctly with Spring's caching proxy:
+ * <ul>
+ *   <li>Empty results are cached (not excluded by unless condition)</li>
+ *   <li>Second fetch uses cached result (no additional API call)</li>
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class CacheIntegrationTest {
+
+    private static WireMockServer wireMockServer;
+
+    @Autowired
+    private PotaClient potaClient;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @TestConfiguration
+    static class WireMockClientConfig {
+        @Bean
+        @Primary
+        PotaClient wireMockPotaClient(WebClient.Builder webClientBuilder, CacheManager cacheManager) {
+            // Access to protected constructor is available because this is in the same package
+            return new PotaClient(webClientBuilder, cacheManager, wireMockServer.baseUrl());
+        }
+    }
+
+    @BeforeAll
+    static void startWireMock() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+    }
+
+    @AfterAll
+    static void stopWireMock() {
+        wireMockServer.stop();
+    }
+
+    @BeforeEach
+    void resetWireMockAndCache() {
+        wireMockServer.resetAll();
+        // Clear cache before each test
+        var cache = cacheManager.getCache("potaActivations");
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+
+    @Test
+    void testCaching_EmptyResult_IsCached_NoSecondApiCall() {
+        // Given: API returns empty array
+        wireMockServer.stubFor(get(urlEqualTo("/"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[]")));
+
+        // When: Fetch twice
+        List<Activation> firstResult = potaClient.fetch();
+        List<Activation> secondResult = potaClient.fetch();
+
+        // Then: Both results should be empty lists
+        assertNotNull(firstResult);
+        assertTrue(firstResult.isEmpty());
+        assertNotNull(secondResult);
+        assertTrue(secondResult.isEmpty());
+
+        // And: API should only be called once (second call used cache)
+        wireMockServer.verify(1, getRequestedFor(urlEqualTo("/")));
+    }
+
+    @Test
+    void testCaching_NonEmptyResult_IsCached_NoSecondApiCall() {
+        // Given: API returns data
+        String jsonResponse = """
+            [
+              {
+                "spotId": 123456,
+                "activator": "W1ABC",
+                "reference": "US-0001",
+                "name": "Test Park",
+                "frequency": "14250",
+                "mode": "SSB",
+                "spotTime": "2025-12-14T12:30:00"
+              }
+            ]
+            """;
+
+        wireMockServer.stubFor(get(urlEqualTo("/"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(jsonResponse)));
+
+        // When: Fetch twice
+        List<Activation> firstResult = potaClient.fetch();
+        List<Activation> secondResult = potaClient.fetch();
+
+        // Then: Both results should have 1 activation
+        assertEquals(1, firstResult.size());
+        assertEquals(1, secondResult.size());
+        assertEquals("W1ABC", firstResult.get(0).activatorCallsign());
+
+        // And: API should only be called once (second call used cache)
+        wireMockServer.verify(1, getRequestedFor(urlEqualTo("/")));
+    }
+
+    @Test
+    void testCaching_CacheIsPopulated_AfterFetch() {
+        // Given: API returns data
+        wireMockServer.stubFor(get(urlEqualTo("/"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("[]")));
+
+        // When: Fetch once
+        potaClient.fetch();
+
+        // Then: Cache should contain the result
+        var cache = cacheManager.getCache("potaActivations");
+        assertNotNull(cache, "potaActivations cache should exist");
+        assertNotNull(cache.get("current"), "Cache entry 'current' should exist after fetch");
+    }
+}

--- a/src/test/java/io/nextskip/common/config/CacheConfigTest.java
+++ b/src/test/java/io/nextskip/common/config/CacheConfigTest.java
@@ -1,0 +1,55 @@
+package io.nextskip.common.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.CacheManager;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Unit tests for CacheConfig.
+ *
+ * <p>Verifies that all cache names used by @Cacheable annotations
+ * are properly registered in the CacheManager.
+ */
+class CacheConfigTest {
+
+    /**
+     * All cache names that @Cacheable annotations reference must be registered.
+     * This test prevents cache name mismatches that would cause caching to silently fail.
+     */
+    @Test
+    void testCacheManager_RegistersAllExpectedCaches() {
+        // Given
+        CacheConfig config = new CacheConfig();
+        CacheManager cacheManager = config.cacheManager();
+
+        // Then: All cache names that @Cacheable annotations reference should exist
+        String[] expectedCaches = {
+            "solarIndices",      // NoaaSwpcClient, HamQslClient
+            "bandConditions",    // HamQslClient
+            "potaActivations",   // PotaClient
+            "sotaActivations",   // SotaClient
+            "meteorShowers",     // MeteorServiceImpl
+            "contests",          // ContestCalendarClient
+            "tleData"            // Future satellite tracking
+        };
+
+        for (String cacheName : expectedCaches) {
+            assertNotNull(cacheManager.getCache(cacheName),
+                "Cache '" + cacheName + "' should be registered in CacheConfig");
+        }
+    }
+
+    @Test
+    void testCacheManager_DefaultCacheIsAvailable() {
+        // Given
+        CacheConfig config = new CacheConfig();
+        CacheManager cacheManager = config.cacheManager();
+
+        // When: Request a cache that wasn't explicitly registered
+        var defaultCache = cacheManager.getCache("someUnregisteredCache");
+
+        // Then: Should get a default cache (CaffeineCacheManager creates on-demand)
+        assertNotNull(defaultCache, "Default cache should be available for unregistered names");
+    }
+}


### PR DESCRIPTION
## Summary

Every page load was triggering fresh API calls to all external data sources instead of using cached data. This PR fixes three root causes:

- **Configuration conflict**: Removed conflicting `spring.cache` auto-config from `application.yml` (CacheConfig.java bean is now sole source of truth)
- **Missing cache registrations**: Added `potaActivations` (2min), `sotaActivations` (2min), `meteorShowers` (2hr) to CacheConfig
- **Empty results not cached**: Fixed `@Cacheable` unless conditions to allow caching legitimate empty results (e.g., 0 SOTA activations)

## Changes

| File | Change |
|------|--------|
| `application.yml` | Remove conflicting Spring cache auto-config |
| `CacheConfig.java` | Add 3 cache registrations + update Javadoc |
| `PotaClient.java` | Fix unless condition: `#result == null` |
| `SotaClient.java` | Fix unless condition: `#result == null` |
| `ContestCalendarClient.java` | Fix unless condition: `#result == null` |
| `MeteorServiceImpl.java` | Fix unless condition: `#result == null` |
| `CacheConfigTest.java` | **NEW** Unit test for cache registration |
| `CacheIntegrationTest.java` | **NEW** Integration test for cache behavior |

## Test plan

- [x] `./gradlew check` passes (all backend tests, quality checks)
- [x] `npm run validate` passes (format, lint, 369 frontend tests)
- [x] Application starts without runtime exceptions
- [x] TypeScript: 0 errors
- [x] E2E tests pass (24/24 Playwright tests)
- [ ] Manual verification: page refresh within TTL shows no new "Successfully fetched..." logs

Fixes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)