### PR TITLE
feat(cache): add scheduled data refresh with eager loading

### DIFF
--- a/src/main/java/io/nextskip/NextSkipApplication.java
+++ b/src/main/java/io/nextskip/NextSkipApplication.java
@@ -3,6 +3,7 @@ package io.nextskip;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * NextSkip - Amateur Radio Activity Dashboard
@@ -14,6 +15,7 @@ import org.springframework.cache.annotation.EnableCaching;
  */
 @SpringBootApplication
 @EnableCaching
+@EnableScheduling
 public class NextSkipApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/io/nextskip/activations/internal/PotaClient.java
+++ b/src/main/java/io/nextskip/activations/internal/PotaClient.java
@@ -7,6 +7,7 @@ import io.nextskip.activations.model.Activation;
 import io.nextskip.activations.model.ActivationType;
 import io.nextskip.activations.model.Park;
 import io.nextskip.common.client.ExternalDataClient;
+import io.nextskip.common.client.RefreshableDataSource;
 import io.nextskip.common.util.ParsingUtils;
 import io.nextskip.propagation.internal.ExternalApiException;
 import org.slf4j.Logger;
@@ -37,11 +38,12 @@ import java.util.List;
  */
 @Component
 @SuppressWarnings("PMD.AvoidCatchingGenericException") // Intentional: wrap unknown exceptions in ExternalApiException
-public class PotaClient implements ExternalDataClient<List<Activation>> {
+public class PotaClient implements ExternalDataClient<List<Activation>>, RefreshableDataSource {
 
     private static final Logger LOG = LoggerFactory.getLogger(PotaClient.class);
 
     private static final String SOURCE_NAME = "POTA";
+    private static final Duration REFRESH_INTERVAL = Duration.ofMinutes(2);
     private static final String POTA_URL = "https://api.pota.app/spot/activator";
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
 
@@ -65,6 +67,16 @@ public class PotaClient implements ExternalDataClient<List<Activation>> {
     @Override
     public String getSourceName() {
         return SOURCE_NAME + " API";
+    }
+
+    @Override
+    public void refresh() {
+        fetch();
+    }
+
+    @Override
+    public Duration getRefreshInterval() {
+        return REFRESH_INTERVAL;
     }
 
     /**

--- a/src/main/java/io/nextskip/activations/internal/SotaClient.java
+++ b/src/main/java/io/nextskip/activations/internal/SotaClient.java
@@ -7,6 +7,7 @@ import io.nextskip.activations.model.Activation;
 import io.nextskip.activations.model.ActivationType;
 import io.nextskip.activations.model.Summit;
 import io.nextskip.common.client.ExternalDataClient;
+import io.nextskip.common.client.RefreshableDataSource;
 import io.nextskip.common.util.ParsingUtils;
 import io.nextskip.propagation.internal.ExternalApiException;
 import org.slf4j.Logger;
@@ -41,11 +42,12 @@ import java.util.List;
  */
 @Component
 @SuppressWarnings("PMD.AvoidCatchingGenericException") // Intentional: wrap unknown exceptions in ExternalApiException
-public class SotaClient implements ExternalDataClient<List<Activation>> {
+public class SotaClient implements ExternalDataClient<List<Activation>>, RefreshableDataSource {
 
     private static final Logger LOG = LoggerFactory.getLogger(SotaClient.class);
 
     private static final String SOURCE_NAME = "SOTA";
+    private static final Duration REFRESH_INTERVAL = Duration.ofMinutes(2);
     private static final String SOTA_URL = "https://api2.sota.org.uk/api/spots/50";
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
     private static final Duration RECENCY_THRESHOLD = Duration.ofMinutes(45);
@@ -70,6 +72,16 @@ public class SotaClient implements ExternalDataClient<List<Activation>> {
     @Override
     public String getSourceName() {
         return SOURCE_NAME + " API";
+    }
+
+    @Override
+    public void refresh() {
+        fetch();
+    }
+
+    @Override
+    public Duration getRefreshInterval() {
+        return REFRESH_INTERVAL;
     }
 
     /**

--- a/src/main/java/io/nextskip/common/client/RefreshableDataSource.java
+++ b/src/main/java/io/nextskip/common/client/RefreshableDataSource.java
@@ -1,0 +1,51 @@
+package io.nextskip.common.client;
+
+import java.time.Duration;
+
+/**
+ * Interface for data sources that can be refreshed on a schedule.
+ *
+ * <p>Implement this interface to have your data source automatically discovered
+ * and scheduled by {@link io.nextskip.common.scheduler.DataRefreshScheduler}.
+ *
+ * <p>The scheduler will:
+ * <ul>
+ *     <li>Call {@link #refresh()} on startup to warm the cache</li>
+ *     <li>Schedule periodic refreshes at the interval returned by {@link #getRefreshInterval()}</li>
+ *     <li>Log refresh activity using {@link #getSourceName()} for identification</li>
+ * </ul>
+ *
+ * <p>This enables the Open-Closed Principle: adding a new data source only requires
+ * implementing this interface - no modifications to the scheduler are needed.
+ */
+public interface RefreshableDataSource {
+
+    /**
+     * Fetches fresh data from the source and updates the cache.
+     *
+     * <p>Implementations should delegate to their cacheable fetch method,
+     * ensuring the cache is refreshed. Any exceptions should be allowed to
+     * propagate - the scheduler will catch and log them.
+     */
+    void refresh();
+
+    /**
+     * Returns the human-readable name of this data source.
+     *
+     * <p>Used for logging refresh activity and identifying the source.
+     *
+     * @return the source name (e.g., "POTA", "SOTA", "NOAA SWPC")
+     */
+    String getSourceName();
+
+    /**
+     * Returns the recommended refresh interval for this data source.
+     *
+     * <p>The scheduler will refresh this source at this interval.
+     * Choose an interval appropriate for the data's update frequency
+     * and the external API's rate limits.
+     *
+     * @return the refresh interval (e.g., {@code Duration.ofMinutes(2)})
+     */
+    Duration getRefreshInterval();
+}

--- a/src/main/java/io/nextskip/common/scheduler/DataRefreshScheduler.java
+++ b/src/main/java/io/nextskip/common/scheduler/DataRefreshScheduler.java
@@ -1,0 +1,111 @@
+package io.nextskip.common.scheduler;
+
+import io.nextskip.common.client.RefreshableDataSource;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * Scheduler that refreshes all data sources on startup and at regular intervals.
+ *
+ * <p>This scheduler automatically discovers all {@link RefreshableDataSource} implementations
+ * via Spring's dependency injection. Adding a new data source only requires implementing
+ * the interface - no modifications to this class are needed (Open-Closed Principle).
+ *
+ * <p>Features:
+ * <ul>
+ *     <li>Eager loading: warms all caches on application startup</li>
+ *     <li>Per-source intervals: each source defines its own refresh interval</li>
+ *     <li>Fault tolerance: failed refreshes are logged, not propagated</li>
+ *     <li>Clean shutdown: cancels all scheduled tasks on bean destruction</li>
+ * </ul>
+ */
+@Component
+@SuppressWarnings("PMD.AvoidCatchingGenericException") // Intentional: safeRefresh catches all exceptions to prevent scheduler crash
+public class DataRefreshScheduler implements DisposableBean {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataRefreshScheduler.class);
+
+    private final List<RefreshableDataSource> sources;
+    private final ThreadPoolTaskScheduler taskScheduler;
+    private final List<ScheduledFuture<?>> scheduledTasks = new ArrayList<>();
+
+    @Value("${nextskip.refresh.eager-load:true}")
+    private boolean eagerLoad;
+
+    /**
+     * Constructs a scheduler with the given data sources.
+     *
+     * @param sources all RefreshableDataSource beans (auto-discovered by Spring)
+     */
+    public DataRefreshScheduler(List<RefreshableDataSource> sources) {
+        this.sources = List.copyOf(sources);  // Defensive copy
+        this.taskScheduler = new ThreadPoolTaskScheduler();
+        this.taskScheduler.setPoolSize(2);
+        this.taskScheduler.setThreadNamePrefix("data-refresh-");
+        this.taskScheduler.initialize();
+    }
+
+    /**
+     * Initializes the scheduler after bean construction.
+     *
+     * <p>If eager loading is enabled (default), refreshes all sources immediately
+     * to warm the caches. Then schedules each source to refresh at its specified interval.
+     */
+    @PostConstruct
+    public void initialize() {
+        if (sources.isEmpty()) {
+            LOG.warn("No RefreshableDataSource beans found - nothing to schedule");
+            return;
+        }
+
+        if (eagerLoad) {
+            LOG.info("Warming cache on startup with {} sources...", sources.size());
+            sources.forEach(this::safeRefresh);
+            LOG.info("Cache warming complete");
+        }
+
+        for (RefreshableDataSource source : sources) {
+            // Use the refresh interval as both initial delay and period
+            // This prevents immediate execution of the scheduled task
+            Instant firstRun = Instant.now().plus(source.getRefreshInterval());
+            ScheduledFuture<?> future = taskScheduler.scheduleAtFixedRate(
+                    () -> safeRefresh(source),
+                    firstRun,
+                    source.getRefreshInterval()
+            );
+            scheduledTasks.add(future);
+            LOG.info("Scheduled {} to refresh every {}", source.getSourceName(), source.getRefreshInterval());
+        }
+    }
+
+    /**
+     * Safely refreshes a data source, catching and logging any exceptions.
+     *
+     * @param source the source to refresh
+     */
+    private void safeRefresh(RefreshableDataSource source) {
+        try {
+            source.refresh();
+            LOG.debug("Refreshed {}", source.getSourceName());
+        } catch (Exception e) {
+            LOG.warn("Failed to refresh {}: {}", source.getSourceName(), e.getMessage());
+        }
+    }
+
+    @Override
+    public void destroy() {
+        LOG.info("Shutting down data refresh scheduler");
+        scheduledTasks.forEach(future -> future.cancel(true));
+        taskScheduler.shutdown();
+    }
+}

--- a/src/main/java/io/nextskip/contests/internal/ContestCalendarClient.java
+++ b/src/main/java/io/nextskip/contests/internal/ContestCalendarClient.java
@@ -3,6 +3,7 @@ package io.nextskip.contests.internal;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import io.nextskip.common.client.ExternalDataClient;
+import io.nextskip.common.client.RefreshableDataSource;
 import io.nextskip.contests.internal.dto.ContestICalDto;
 import io.nextskip.propagation.internal.ExternalApiException;
 import net.fortuna.ical4j.data.CalendarBuilder;
@@ -51,11 +52,12 @@ import java.util.Optional;
  */
 @org.springframework.stereotype.Component
 @SuppressWarnings("PMD.AvoidCatchingGenericException") // Intentional: wrap unknown exceptions in ExternalApiException
-public class ContestCalendarClient implements ExternalDataClient<List<ContestICalDto>> {
+public class ContestCalendarClient implements ExternalDataClient<List<ContestICalDto>>, RefreshableDataSource {
 
     private static final Logger LOG = LoggerFactory.getLogger(ContestCalendarClient.class);
 
     private static final String SOURCE_NAME = "WA7BNM";
+    private static final Duration REFRESH_INTERVAL = Duration.ofHours(6);
     private static final String CACHE_NAME = "contests";
     private static final String CALENDAR_URL = "https://www.contestcalendar.com/weeklycontcustom.php";
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(15);
@@ -80,6 +82,16 @@ public class ContestCalendarClient implements ExternalDataClient<List<ContestICa
     @Override
     public String getSourceName() {
         return SOURCE_NAME + " Contest Calendar";
+    }
+
+    @Override
+    public void refresh() {
+        fetch();
+    }
+
+    @Override
+    public Duration getRefreshInterval() {
+        return REFRESH_INTERVAL;
     }
 
     /**

--- a/src/main/java/io/nextskip/meteors/internal/MeteorServiceImpl.java
+++ b/src/main/java/io/nextskip/meteors/internal/MeteorServiceImpl.java
@@ -1,5 +1,6 @@
 package io.nextskip.meteors.internal;
 
+import io.nextskip.common.client.RefreshableDataSource;
 import io.nextskip.common.model.EventStatus;
 import io.nextskip.meteors.api.MeteorService;
 import io.nextskip.meteors.model.MeteorShower;
@@ -8,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -19,15 +21,31 @@ import java.util.Optional;
  * filtered views for different use cases.
  */
 @Service
-public class MeteorServiceImpl implements MeteorService {
+public class MeteorServiceImpl implements MeteorService, RefreshableDataSource {
 
     private static final Logger LOG = LoggerFactory.getLogger(MeteorServiceImpl.class);
     private static final int DEFAULT_LOOKAHEAD_DAYS = 30;
+    private static final Duration REFRESH_INTERVAL = Duration.ofHours(1);
 
     private final MeteorShowerDataLoader dataLoader;
 
     public MeteorServiceImpl(MeteorShowerDataLoader dataLoader) {
         this.dataLoader = dataLoader;
+    }
+
+    @Override
+    public String getSourceName() {
+        return "Meteor Showers";
+    }
+
+    @Override
+    public void refresh() {
+        getMeteorShowers();
+    }
+
+    @Override
+    public Duration getRefreshInterval() {
+        return REFRESH_INTERVAL;
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,11 @@ spring:
   application:
     name: nextskip
 
+# Data Refresh Scheduler Configuration
+nextskip:
+  refresh:
+    eager-load: true  # Warm all caches on application startup
+
 # Resilience4j Circuit Breaker Configuration
 resilience4j:
   circuitbreaker:

--- a/src/test/java/io/nextskip/common/scheduler/DataRefreshSchedulerIntegrationTest.java
+++ b/src/test/java/io/nextskip/common/scheduler/DataRefreshSchedulerIntegrationTest.java
@@ -1,0 +1,77 @@
+package io.nextskip.common.scheduler;
+
+import io.nextskip.common.client.RefreshableDataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for DataRefreshScheduler.
+ *
+ * <p>Verifies:
+ * <ul>
+ *   <li>Scheduler bean is loaded in Spring context</li>
+ *   <li>All RefreshableDataSource implementations are discovered</li>
+ *   <li>OCP: sources are auto-discovered without scheduler modification</li>
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "nextskip.refresh.eager-load=false"  // Disable eager loading for test stability
+})
+class DataRefreshSchedulerIntegrationTest {
+
+    @Autowired
+    private DataRefreshScheduler scheduler;
+
+    @Autowired
+    private List<RefreshableDataSource> sources;
+
+    @Test
+    void testContext_SchedulerBeanLoaded() {
+        assertNotNull(scheduler, "DataRefreshScheduler should be loaded as a Spring bean");
+    }
+
+    @Test
+    void testContext_AllSourcesDiscovered() {
+        // Should auto-discover all RefreshableDataSource implementations
+        assertFalse(sources.isEmpty(), "At least one RefreshableDataSource should be discovered");
+        assertTrue(sources.size() >= 6,
+                "Expected at least 6 sources (POTA, SOTA, NOAA, HamQSL, Contests, Meteors), found: "
+                        + sources.size());
+    }
+
+    @Test
+    void testOcp_SourcesHaveRequiredMethods() {
+        // Verify all sources implement the interface correctly
+        for (RefreshableDataSource source : sources) {
+            assertNotNull(source.getSourceName(), "Source name should not be null");
+            assertFalse(source.getSourceName().isBlank(), "Source name should not be blank");
+            assertNotNull(source.getRefreshInterval(), "Refresh interval should not be null");
+            assertTrue(source.getRefreshInterval().toMillis() > 0,
+                    "Refresh interval should be positive");
+        }
+    }
+
+    @Test
+    void testOcp_KnownSourcesDiscovered() {
+        // Verify that the list contains expected source names
+        List<String> sourceNames = sources.stream()
+                .map(RefreshableDataSource::getSourceName)
+                .toList();
+
+        assertTrue(sourceNames.contains("POTA API"), "POTA source should be discovered");
+        assertTrue(sourceNames.contains("SOTA API"), "SOTA source should be discovered");
+        assertTrue(sourceNames.contains("NOAA"), "NOAA source should be discovered");
+        assertTrue(sourceNames.contains("HamQSL"), "HamQSL source should be discovered");
+        assertTrue(sourceNames.contains("WA7BNM Contest Calendar"), "WA7BNM (Contests) source should be discovered");
+        assertTrue(sourceNames.contains("Meteor Showers"), "Meteor Showers source should be discovered");
+    }
+}

--- a/src/test/java/io/nextskip/common/scheduler/DataRefreshSchedulerTest.java
+++ b/src/test/java/io/nextskip/common/scheduler/DataRefreshSchedulerTest.java
@@ -1,0 +1,115 @@
+package io.nextskip.common.scheduler;
+
+import io.nextskip.common.client.RefreshableDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for DataRefreshScheduler.
+ *
+ * <p>Verifies:
+ * <ul>
+ *   <li>Eager loading refreshes all sources on startup</li>
+ *   <li>Failed refreshes don't propagate exceptions</li>
+ *   <li>Sources are scheduled at their defined intervals</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+class DataRefreshSchedulerTest {
+
+    private static final String EAGER_LOAD_FIELD = "eagerLoad";
+
+    @Mock
+    private RefreshableDataSource source1;
+
+    @Mock
+    private RefreshableDataSource source2;
+
+    private DataRefreshScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(source1.getSourceName()).thenReturn("Source1");
+        // Use a long interval to prevent scheduled task from running during test
+        lenient().when(source1.getRefreshInterval()).thenReturn(Duration.ofHours(1));
+        lenient().when(source2.getSourceName()).thenReturn("Source2");
+        lenient().when(source2.getRefreshInterval()).thenReturn(Duration.ofHours(1));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (scheduler != null) {
+            scheduler.destroy();
+        }
+    }
+
+    @Test
+    void testInitialize_WithEagerLoad_RefreshesAllSources() {
+        scheduler = new DataRefreshScheduler(List.of(source1, source2));
+        ReflectionTestUtils.setField(scheduler, EAGER_LOAD_FIELD, true);
+
+        scheduler.initialize();
+
+        // At minimum, each source should be refreshed once (eager load)
+        verify(source1, atLeastOnce()).refresh();
+        verify(source2, atLeastOnce()).refresh();
+    }
+
+    @Test
+    void testInitialize_WithEagerLoadDisabled_SkipsInitialRefresh() {
+        scheduler = new DataRefreshScheduler(List.of(source1, source2));
+        ReflectionTestUtils.setField(scheduler, EAGER_LOAD_FIELD, false);
+
+        scheduler.initialize();
+
+        // With eager load disabled, sources should not be refreshed immediately
+        // The scheduled task won't run during the test due to the long interval
+        verify(source1, never()).refresh();
+        verify(source2, never()).refresh();
+    }
+
+    @Test
+    void testSafeRefresh_FailureDoesNotPropagate() {
+        doThrow(new RuntimeException("API down")).when(source1).refresh();
+        scheduler = new DataRefreshScheduler(List.of(source1, source2));
+        ReflectionTestUtils.setField(scheduler, EAGER_LOAD_FIELD, true);
+
+        // Should not throw - failures are logged, not propagated
+        assertDoesNotThrow(() -> scheduler.initialize());
+
+        // source2 should still be refreshed despite source1 failure
+        verify(source2, atLeastOnce()).refresh();
+    }
+
+    @Test
+    void testInitialize_EmptySources_DoesNotThrow() {
+        DataRefreshScheduler emptyScheduler = new DataRefreshScheduler(List.of());
+        ReflectionTestUtils.setField(emptyScheduler, EAGER_LOAD_FIELD, true);
+
+        // Should not throw with empty sources list
+        assertDoesNotThrow(emptyScheduler::initialize);
+
+        emptyScheduler.destroy();
+    }
+
+    @Test
+    void testDestroy_CancelsScheduledTasks() {
+        scheduler = new DataRefreshScheduler(List.of(source1, source2));
+        ReflectionTestUtils.setField(scheduler, EAGER_LOAD_FIELD, true);
+        scheduler.initialize();
+
+        // Should not throw on destroy
+        assertDoesNotThrow(() -> scheduler.destroy());
+    }
+}


### PR DESCRIPTION
## Summary

Implements scheduled background cache refresh using OCP-compliant design:

- **RefreshableDataSource interface**: New abstraction for auto-discovered data sources
- **DataRefreshScheduler**: Uses `List<RefreshableDataSource>` injection for OCP compliance
- **6 clients implemented**: POTA, SOTA, NOAA, HamQSL, ContestCalendar, MeteorService
- **Eager loading**: Warms all caches on startup (configurable via `nextskip.refresh.eager-load`)
- **Per-source intervals**: Each source defines its own refresh interval

Adding new data sources requires **zero changes** to the scheduler (Open-Closed Principle).

## Files Changed

**New Files:**
- `RefreshableDataSource.java` - Interface for auto-discovered data sources
- `DataRefreshScheduler.java` - OCP-compliant scheduler with List injection
- `DataRefreshSchedulerTest.java` - Unit tests
- `DataRefreshSchedulerIntegrationTest.java` - Integration tests

**Modified Files:**
- 6 clients: PotaClient, SotaClient, NoaaSwpcClient, HamQslClient, ContestCalendarClient, MeteorServiceImpl
- NextSkipApplication.java - Added @EnableScheduling
- application.yml - Added eager-load config

## Test Plan

- [x] All unit tests pass
- [x] All integration tests pass
- [x] `./gradlew check` passes (Checkstyle, PMD, SpotBugs, JaCoCo)
- [ ] Manual: Start app and verify "Warming cache on startup" log message
- [ ] Manual: Verify "Scheduled X to refresh every PT2M" log messages

Closes #141