### PR TITLE
build: add .env.production for Vite build-time env vars

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,2 @@
+VITE_FARO_COLLECTOR_URL=https://faro-collector-prod-us-west-0.grafana.net/collect/3d41a45f9d4600240bb90ffdb9a71237
+VITE_TRACE_CORS_URLS=nextskip\.io


### PR DESCRIPTION
The Faro collector URL needs to be available at Vite build time. This is a client-side URL that appears in the bundle anyway, so not a secret.