### PR TITLE
fix(dashboard): change HF Band Conditions card to tall aspect ratio

### DIFF
--- a/src/main/frontend/components/cards/propagation/index.tsx
+++ b/src/main/frontend/components/cards/propagation/index.tsx
@@ -122,7 +122,7 @@ const bandConditionsCard: CardDefinition = {
     return {
       id: 'band-conditions',
       type: 'band-conditions',
-      size: 'hero',
+      size: 'tall',
       priority,
       hotness,
     };

--- a/src/test/frontend/hooks/useDashboardCards.test.ts
+++ b/src/test/frontend/hooks/useDashboardCards.test.ts
@@ -380,7 +380,7 @@ describe('useDashboardCards', () => {
       expect(result.current[0].id).toBe('solar-indices');
     });
 
-    it('should have correct id, type, size=wide', () => {
+    it('should have correct id, type, size=tall', () => {
       const dashboardData: DashboardData = {
         propagation: createMockPropagationResponse({
           solarIndices: undefined,
@@ -393,7 +393,7 @@ describe('useDashboardCards', () => {
       expect(result.current[0]).toMatchObject({
         id: 'band-conditions',
         type: 'band-conditions',
-        size: 'hero',
+        size: 'tall',
       });
     });
 


### PR DESCRIPTION
## Summary

- Changes the HF Band Conditions card from `hero` (1:1 square) to `tall` (1:2 portrait) aspect ratio
- The `@masonry-grid/react` library interprets Frame dimensions as **aspect ratio**, not grid units
- This makes the card match POTA/SOTA cards height, providing proper vertical space for content

## Root Cause

| Size | Aspect Ratio | Visual Shape |
|------|--------------|--------------|
| `hero` (was) | 2:2 = 1:1 | Square |
| `tall` (now) | 1:2 | Tall rectangle |

## Changes

- `src/main/frontend/components/cards/propagation/index.tsx`: `size: 'hero'` → `size: 'tall'`
- `src/test/frontend/hooks/useDashboardCards.test.ts`: Updated test expectation

## Test Plan

- [x] All 369 frontend tests pass
- [x] ESLint passes
- [ ] Visual verification that card displays properly

## Related

- Refs #155 - Future refactoring of card size naming system