### PR TITLE
feat(observability): add Grafana Cloud Pyroscope continuous profiling

### DIFF
--- a/.github/DEPENDENCY_MANAGEMENT.md
+++ b/.github/DEPENDENCY_MANAGEMENT.md
@@ -18,7 +18,19 @@ npm install --package-lock-only
 This syncs npm `package.json` and `package-lock.json` with Gradle-managed Vaadin versions.
 
 **Ignored npm packages** (controlled by Vaadin Gradle plugin):
+
 - `@vaadin/*`, `react*`, `lit`, `vite`, `typescript`, `workbox-*`
+
+## Observability Agents
+
+Renovate tracks these Java agents via custom regex managers:
+
+| Agent        | Version Catalog Key  | GitHub Repo                          |
+| ------------ | -------------------- | ------------------------------------ |
+| Grafana OTEL | `grafana-otel-agent` | `grafana/grafana-opentelemetry-java` |
+| Pyroscope    | `pyroscope-agent`    | `grafana/pyroscope-java`             |
+
+Both are downloaded at build time by Gradle tasks (`downloadOtelAgent`, `downloadPyroscopeAgent`) and included in the Docker image.
 
 ## Gradle Dependency Locking
 
@@ -29,6 +41,7 @@ The `gradle.lockfile` is required for Renovate to detect changes and trigger pos
 ## Renovate PAT Permissions
 
 Fine-grained token scoped to this repo with:
+
 - Contents: Read and write
 - Pull requests: Read and write
 - Commit statuses: Read and write

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,14 @@
       "matchStrings": ["grafana-otel-agent\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "grafana/grafana-opentelemetry-java",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Pyroscope Java agent from GitHub releases",
+      "managerFilePatterns": ["/gradle/libs\\.versions\\.toml$/"],
+      "matchStrings": ["pyroscope-agent\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "grafana/pyroscope-java",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,10 @@ FROM gcr.io/distroless/java25-debian13
 
 WORKDIR /app
 
-# Copy the built JAR and OTEL agent from builder stage
+# Copy the built JAR and agents from builder stage
 COPY --from=builder /app/build/libs/*.jar app.jar
 COPY --from=builder /app/build/otel-agent/grafana-opentelemetry-java.jar otel-agent.jar
+COPY --from=builder /app/build/pyroscope-agent/pyroscope.jar pyroscope-agent.jar
 
 # Distroless runs as non-root by default (uid 65532)
 # Spring Boot optimizations via JAVA_TOOL_OPTIONS (distroless doesn't support JAVA_OPTS)
@@ -39,5 +40,6 @@ ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
 EXPOSE 8080
 
 # Distroless has no shell, so use exec form
-# Agent enabled by default; disable with OTEL_JAVAAGENT_ENABLED=false
-ENTRYPOINT ["java", "-javaagent:/app/otel-agent.jar", "-jar", "app.jar"]
+# OTEL: disable with OTEL_JAVAAGENT_ENABLED=false
+# Pyroscope: disable by not setting PYROSCOPE_SERVER_ADDRESS
+ENTRYPOINT ["java", "-javaagent:/app/otel-agent.jar", "-javaagent:/app/pyroscope-agent.jar", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ tasks.named('jar') {
 // The vaadinBuildFrontend task writes to build/resources/main/ AFTER processResources,
 // so we need to explicitly include these files in the bootJar
 tasks.named('bootJar') {
-    dependsOn 'vaadinBuildFrontend', 'downloadOtelAgent'
+    dependsOn 'vaadinBuildFrontend', 'downloadOtelAgent', 'downloadPyroscopeAgent'
 
     // Explicitly copy Vaadin production files into the JAR
     into('BOOT-INF/classes') {
@@ -143,6 +143,27 @@ tasks.register('downloadOtelAgent') {
 
         ant.get(src: agentUrl, dest: destFile, skipexisting: false)
         println "Downloaded Grafana OTEL agent v${otelAgentVersion} to ${destFile}"
+    }
+}
+
+// Pyroscope profiling agent configuration
+def pyroscopeAgentVersion = libs.versions.pyroscope.agent.get()
+def pyroscopeAgentDir = layout.buildDirectory.dir("pyroscope-agent")
+def pyroscopeAgentJar = pyroscopeAgentDir.map { it.file("pyroscope.jar") }
+
+tasks.register('downloadPyroscopeAgent') {
+    description = 'Downloads the Pyroscope Java profiling agent'
+    group = 'observability'
+
+    outputs.file(pyroscopeAgentJar)
+
+    doLast {
+        def agentUrl = "https://github.com/grafana/pyroscope-java/releases/download/v${pyroscopeAgentVersion}/pyroscope.jar"
+        def destFile = pyroscopeAgentJar.get().asFile
+        destFile.parentFile.mkdirs()
+
+        ant.get(src: agentUrl, dest: destFile, skipexisting: false)
+        println "Downloaded Pyroscope agent v${pyroscopeAgentVersion} to ${destFile}"
     }
 }
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -17,6 +17,34 @@ Disable agent: `OTEL_JAVAAGENT_ENABLED=false`
 
 Agent version: `gradle/libs.versions.toml` → `grafana-otel-agent`
 
+## Continuous Profiling (Pyroscope)
+
+Continuous profiling via [Grafana Pyroscope Java agent](https://grafana.com/docs/pyroscope/latest/configure-client/language-sdks/java/).
+
+### Configuration
+
+Get credentials: [Grafana Cloud Portal](https://grafana.com/products/cloud/) → Your Stack → Profiles → Configure
+
+| Variable                        | Value                                                 |
+| ------------------------------- | ----------------------------------------------------- |
+| `PYROSCOPE_APPLICATION_NAME`    | `nextskip`                                            |
+| `PYROSCOPE_SERVER_ADDRESS`      | `https://profiles-prod-XXX.grafana.net` (from portal) |
+| `PYROSCOPE_BASIC_AUTH_USER`     | `<instance-id>` (from portal)                         |
+| `PYROSCOPE_BASIC_AUTH_PASSWORD` | `<api-key>` (from portal)                             |
+
+### Full Profiling (CPU + Allocation + Lock)
+
+| Variable                   | Value    | Description                        |
+| -------------------------- | -------- | ---------------------------------- |
+| `PYROSCOPE_FORMAT`         | `jfr`    | JFR format for multi-event support |
+| `PYROSCOPE_PROFILER_EVENT` | `itimer` | CPU profiling event type           |
+| `PYROSCOPE_PROFILER_ALLOC` | `512k`   | Allocation profiling threshold     |
+| `PYROSCOPE_PROFILER_LOCK`  | `10ms`   | Lock contention threshold          |
+
+Disable: Omit `PYROSCOPE_SERVER_ADDRESS` (agent gracefully handles missing config).
+
+Agent version: `gradle/libs.versions.toml` → `pyroscope-agent`
+
 ## Frontend
 
 Uses [Grafana Faro React SDK](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/) for browser telemetry with React Router integration.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ spring-dependency-management = "1.1.7"
 
 # Observability
 grafana-otel-agent = "2.22.0"
+pyroscope-agent = "2.1.2"
 
 # Quality & testing tools
 # NOTE: checkstyle, pmd, spotbugs-tool, and jacoco versions moved to direct literals in build.gradle


### PR DESCRIPTION
## Summary

- Adds Pyroscope Java agent for continuous profiling (CPU, allocation, lock)
- Follows existing OTEL agent pattern with Gradle download task
- Integrates into Docker image with dual `-javaagent` entrypoint
- Configures Renovate for automatic version updates

## Configuration

Set these environment variables in production:

| Variable | Value |
|----------|-------|
| `PYROSCOPE_APPLICATION_NAME` | `nextskip` |
| `PYROSCOPE_SERVER_ADDRESS` | `https://profiles-prod-XXX.grafana.net` |
| `PYROSCOPE_BASIC_AUTH_USER` | `<instance-id>` |
| `PYROSCOPE_BASIC_AUTH_PASSWORD` | `<api-key>` |
| `PYROSCOPE_FORMAT` | `jfr` |
| `PYROSCOPE_PROFILER_EVENT` | `itimer` |
| `PYROSCOPE_PROFILER_ALLOC` | `512k` |
| `PYROSCOPE_PROFILER_LOCK` | `10ms` |

Profiling is disabled by default when `PYROSCOPE_SERVER_ADDRESS` is not set.

## Test plan

- [x] `./gradlew downloadOtelAgent downloadPyroscopeAgent` downloads both agents
- [x] `./gradlew build` passes
- [ ] Docker build succeeds with both agents
- [ ] Production deployment with Grafana Cloud credentials shows profiles