### PR TITLE
perf(e2e): optimize wait strategies for 6x faster tests

### DIFF
--- a/src/test/e2e/dashboard.spec.ts
+++ b/src/test/e2e/dashboard.spec.ts
@@ -17,8 +17,7 @@ test.describe('Dashboard', () => {
       localStorage.setItem('nextskip-visited', 'true');
     });
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    // Wait for Vaadin to fully initialize by checking for the outlet div to have content
+    // Wait for Vaadin to fully initialize - this is the actual ready signal
     await page.waitForSelector('#outlet > *', { timeout: 10000 });
   });
 
@@ -73,7 +72,7 @@ test.describe('Dashboard', () => {
 
     // Click once to go to dark
     await themeToggle.click();
-    await page.waitForTimeout(100);
+    await expect(page.locator('html[data-theme="dark"]')).toBeVisible();
 
     // Click again to go to light
     await themeToggle.click();
@@ -95,7 +94,6 @@ test.describe('Dashboard', () => {
 
     // Reload the page
     await page.reload();
-    await page.waitForLoadState('networkidle');
     await page.waitForSelector('#outlet > *', { timeout: 10000 });
 
     // Verify dark theme is still applied
@@ -109,7 +107,6 @@ test.describe('Dashboard', () => {
     const freshPage = await freshContext.newPage();
 
     await freshPage.goto('/');
-    await freshPage.waitForLoadState('networkidle');
     await freshPage.waitForSelector('#outlet > *', { timeout: 10000 });
 
     // Help modal should be visible on first visit

--- a/src/test/e2e/help.spec.ts
+++ b/src/test/e2e/help.spec.ts
@@ -18,10 +18,8 @@ test.describe('Help System', () => {
       localStorage.setItem('nextskip-visited', 'true');
     });
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    await page.waitForSelector('#outlet > *', { timeout: 10000 });
-    // Wait for loading to complete
-    await page.waitForSelector('.loading', { state: 'hidden', timeout: 30000 });
+    // Wait for Vaadin to fully initialize and help button to be ready
+    await page.waitForSelector('.help-button', { timeout: 10000 });
   });
 
   test('help button is visible in header', { timeout: 30_000 }, async ({ page }) => {
@@ -112,12 +110,9 @@ test.describe('Help System', () => {
     if (await solarTab.isVisible()) {
       await solarTab.click();
 
-      // Give time for smooth scroll
-      await page.waitForTimeout(500);
-
-      // The section should be in view
+      // The section should scroll into view
       const solarSection = page.locator('#help-section-solar-indices');
-      await expect(solarSection).toBeInViewport();
+      await expect(solarSection).toBeInViewport({ timeout: 2000 });
     }
   });
 
@@ -174,9 +169,8 @@ test.describe('Help System - Mobile', () => {
       localStorage.setItem('nextskip-visited', 'true');
     });
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    await page.waitForSelector('#outlet > *', { timeout: 10000 });
-    await page.waitForSelector('.loading', { state: 'hidden', timeout: 30000 });
+    // Wait for Vaadin to fully initialize and help button to be ready
+    await page.waitForSelector('.help-button', { timeout: 10000 });
   });
 
   test('modal displays as full-screen sheet', { timeout: 30_000 }, async ({ page }) => {


### PR DESCRIPTION
## Summary
- Remove `networkidle` waits that blocked on background API polling
- Remove redundant wait chains (outlet → loading → networkidle)
- Replace hard-coded `waitForTimeout()` with assertion-based waits
- Wait for specific ready signals instead of generic load states

## Performance
| Metric | Before | After |
|--------|--------|-------|
| Total runtime | 2.8 min | 30s |
| Test execution | ~2.5 min | ~20s |

## Test plan
- [x] All 25 E2E tests pass
- [x] Tests verified on clean server startup