### PR TITLE
feat(observability): add environment label and rename service to nextskip-frontend

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,3 @@
 VITE_FARO_COLLECTOR_URL=https://faro-collector-prod-us-west-0.grafana.net/collect/3d41a45f9d4600240bb90ffdb9a71237
 VITE_TRACE_CORS_URLS=nextskip\.io
+VITE_ENVIRONMENT=production

--- a/src/main/frontend/observability.ts
+++ b/src/main/frontend/observability.ts
@@ -20,8 +20,9 @@ if (collectorUrl) {
   initializeFaro({
     url: collectorUrl,
     app: {
-      name: 'nextskip',
+      name: 'nextskip-frontend',
       version: import.meta.env.VITE_APP_VERSION || '0.0.0',
+      environment: import.meta.env.VITE_ENVIRONMENT || 'development',
     },
     instrumentations: [
       ...getWebInstrumentations(),

--- a/types.d.ts
+++ b/types.d.ts
@@ -21,6 +21,7 @@ interface ImportMetaEnv {
   readonly VITE_FARO_COLLECTOR_URL?: string;
   readonly VITE_TRACE_CORS_URLS?: string;
   readonly VITE_APP_VERSION?: string;
+  readonly VITE_ENVIRONMENT?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Add `VITE_ENVIRONMENT=production` to `.env.production`
- Add `environment` field to Faro `app` config
- Rename service from `nextskip` to `nextskip-frontend` for clarity

This enables Grafana dashboards and alerts to distinguish between production and development environments, and clearly identifies this as the frontend service.

## Test plan
- [ ] Verify Faro telemetry shows `app.name: nextskip-frontend` in Grafana Cloud
- [ ] Verify Faro telemetry shows `app.environment: production` in Grafana Cloud
- [ ] Verify local dev defaults to `development` environment