### PR TITLE
feat(seo): add core SEO meta tags, Open Graph, and Twitter Cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "no-name",
       "license": "UNLICENSED",
       "dependencies": {
+        "@dr.pogodin/react-helmet": "^3.0.5",
         "@grafana/faro-react": "^2.1.0",
         "@grafana/faro-web-tracing": "^2.1.0",
         "@masonry-grid/react": "^1.1.1",
@@ -1882,7 +1883,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2081,6 +2081,18 @@
       "peer": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dr.pogodin/react-helmet": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@dr.pogodin/react-helmet/-/react-helmet-3.0.5.tgz",
+      "integrity": "sha512-1nOTG6qxtr+Of4qlin/triEk0eahGh5/qJf1hRJKlrTPLDfxLVi6hopiVeeioPFYULbcI7i6tihrtlZT4u8+sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "peerDependencies": {
+        "react": "19"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "validate:full": "npm run validate && npm run e2e"
   },
   "dependencies": {
+    "@dr.pogodin/react-helmet": "^3.0.5",
     "@grafana/faro-react": "^2.1.0",
     "@grafana/faro-web-tracing": "^2.1.0",
     "@masonry-grid/react": "^1.1.1",

--- a/src/main/frontend/components/seo/SEO.tsx
+++ b/src/main/frontend/components/seo/SEO.tsx
@@ -1,0 +1,39 @@
+import { Helmet } from '@dr.pogodin/react-helmet';
+
+interface SEOProps {
+  title: string;
+  description?: string;
+  canonicalUrl?: string;
+  ogImage?: string;
+}
+
+const DEFAULT_DESCRIPTION =
+  'Find the best amateur radio opportunities. Track propagation, portable activations, contests, satellites, and more in one dashboard.';
+
+export function Seo({ title, description, canonicalUrl, ogImage }: SEOProps) {
+  const fullTitle = `${title} | NextSkip`;
+  const desc = description || DEFAULT_DESCRIPTION;
+  const url = canonicalUrl || 'https://nextskip.io';
+  const image = ogImage || 'https://nextskip.io/og-image.svg';
+
+  return (
+    <Helmet>
+      <title>{fullTitle}</title>
+      <meta name="description" content={desc} />
+      <link rel="canonical" href={url} />
+
+      {/* Open Graph */}
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={desc} />
+      <meta property="og:url" content={url} />
+      <meta property="og:image" content={image} />
+      <meta property="og:type" content="website" />
+
+      {/* Twitter Card */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={desc} />
+      <meta name="twitter:image" content={image} />
+    </Helmet>
+  );
+}

--- a/src/main/frontend/components/seo/index.ts
+++ b/src/main/frontend/components/seo/index.ts
@@ -1,0 +1,1 @@
+export { Seo } from './SEO';

--- a/src/main/frontend/index.tsx
+++ b/src/main/frontend/index.tsx
@@ -2,6 +2,7 @@ import './observability';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { HelmetProvider } from '@dr.pogodin/react-helmet';
 import App from './App';
 import './styles/global.css';
 
@@ -10,8 +11,10 @@ const root = createRoot(container!);
 
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <HelmetProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </HelmetProvider>
   </React.StrictMode>,
 );

--- a/src/main/frontend/views/DashboardView.tsx
+++ b/src/main/frontend/views/DashboardView.tsx
@@ -16,6 +16,7 @@ import { useDashboardCards } from '../hooks/useDashboardCards';
 import { getRegisteredCards } from '../components/cards/CardRegistry';
 import { ThemeToggle } from '../components/ThemeToggle';
 import { HelpButton, HelpModal } from '../components/help';
+import { Seo } from '../components/seo';
 import './DashboardView.css';
 
 // Import card modules to trigger registration
@@ -70,9 +71,6 @@ function DashboardView() {
   }, []); // Empty deps: setState functions are stable, Hilla endpoint methods are static
 
   useEffect(() => {
-    // Set document title
-    document.title = 'NextSkip - Amateur Radio Activity Dashboard';
-
     // Initial fetch
     fetchData();
 
@@ -164,6 +162,7 @@ function DashboardView() {
 
   return (
     <div className="dashboard">
+      <Seo title="Amateur Radio Activity Dashboard" />
       <header className="dashboard-header">
         <div className="header-info">
           <div className="header-row">

--- a/src/main/resources/static/og-image.svg
+++ b/src/main/resources/static/og-image.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="wave-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="100%" style="stop-color:#22d3ee"/>
+    </linearGradient>
+    <linearGradient id="text-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#818cf8"/>
+      <stop offset="100%" style="stop-color:#67e8f9"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Dark background -->
+  <rect width="1200" height="630" fill="#0d1117"/>
+
+  <!-- Radio waves (scaled from favicon) -->
+  <g transform="translate(120, 200) scale(6)">
+    <path d="M8 24 Q8 16 16 16" fill="none" stroke="url(#wave-gradient)" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M8 24 Q8 12 20 12" fill="none" stroke="url(#wave-gradient)" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M8 24 Q8 8 24 8" fill="none" stroke="url(#wave-gradient)" stroke-width="2.5" stroke-linecap="round"/>
+    <circle cx="8" cy="24" r="3" fill="url(#wave-gradient)"/>
+  </g>
+
+  <!-- NextSkip title -->
+  <text x="380" y="320" font-family="Inter, system-ui, sans-serif" font-size="120" font-weight="600" fill="url(#text-gradient)">NextSkip</text>
+
+  <!-- Tagline -->
+  <text x="380" y="400" font-family="Inter, system-ui, sans-serif" font-size="36" fill="rgba(255,255,255,0.7)">Amateur Radio Activity Dashboard</text>
+
+  <!-- URL -->
+  <text x="380" y="520" font-family="Inter, system-ui, sans-serif" font-size="28" fill="rgba(255,255,255,0.5)">nextskip.io</text>
+</svg>

--- a/src/main/resources/static/robots.txt
+++ b/src/main/resources/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://nextskip.io/sitemap.xml

--- a/src/main/resources/static/sitemap.xml
+++ b/src/main/resources/static/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://nextskip.io/</loc>
+    <changefreq>hourly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/src/test/frontend/components/seo/SEO.test.tsx
+++ b/src/test/frontend/components/seo/SEO.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for SEO component.
+ *
+ * Tests meta tag rendering and default values for SEO optimization.
+ */
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { HelmetProvider } from '@dr.pogodin/react-helmet';
+import { Seo } from 'Frontend/components/seo/SEO';
+
+/**
+ * Helper to render components wrapped with HelmetProvider.
+ */
+const renderWithHelmet = (ui: React.ReactElement) => render(<HelmetProvider>{ui}</HelmetProvider>);
+
+/**
+ * Helper to get meta tag content by name or property.
+ */
+const getMetaContent = (attr: 'name' | 'property', value: string): string | null => {
+  const meta = document.querySelector(`meta[${attr}="${value}"]`);
+  return meta?.getAttribute('content') || null;
+};
+
+describe('SEO', () => {
+  beforeEach(() => {
+    // Clear any existing meta tags before each test
+    document.head.innerHTML = '';
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('title handling', () => {
+    it('should render title with NextSkip suffix', () => {
+      renderWithHelmet(<Seo title="Test Page" />);
+
+      expect(document.title).toBe('Test Page | NextSkip');
+    });
+
+    it('should update title when prop changes', () => {
+      const { rerender } = renderWithHelmet(<Seo title="First" />);
+      expect(document.title).toBe('First | NextSkip');
+
+      rerender(
+        <HelmetProvider>
+          <Seo title="Second" />
+        </HelmetProvider>,
+      );
+      expect(document.title).toBe('Second | NextSkip');
+    });
+  });
+
+  describe('description meta tag', () => {
+    it('should use default description when none provided', () => {
+      renderWithHelmet(<Seo title="Test" />);
+
+      const description = getMetaContent('name', 'description');
+      expect(description).toContain('amateur radio opportunities');
+    });
+
+    it('should use custom description when provided', () => {
+      renderWithHelmet(<Seo title="Test" description="Custom description" />);
+
+      const description = getMetaContent('name', 'description');
+      expect(description).toBe('Custom description');
+    });
+  });
+
+  describe('canonical URL', () => {
+    it('should set default canonical URL', () => {
+      renderWithHelmet(<Seo title="Test" />);
+
+      const canonical = document.querySelector('link[rel="canonical"]');
+      expect(canonical?.getAttribute('href')).toBe('https://nextskip.io');
+    });
+
+    it('should use custom canonical URL when provided', () => {
+      renderWithHelmet(<Seo title="Test" canonicalUrl="https://nextskip.io/page" />);
+
+      const canonical = document.querySelector('link[rel="canonical"]');
+      expect(canonical?.getAttribute('href')).toBe('https://nextskip.io/page');
+    });
+  });
+
+  describe('Open Graph meta tags', () => {
+    it('should render og:title', () => {
+      renderWithHelmet(<Seo title="Test" />);
+
+      expect(getMetaContent('property', 'og:title')).toBe('Test | NextSkip');
+    });
+
+    it('should render og:description', () => {
+      renderWithHelmet(<Seo title="Test" />);
+
+      const ogDesc = getMetaContent('property', 'og:description');
+      expect(ogDesc).toContain('amateur radio opportunities');
+    });
+
+    it('should render og:url', () => {
+      renderWithHelmet(<Seo title="Test" />);
+
+      expect(getMetaContent('property', 'og:url')).toBe('https://nextskip.io');
+    });
+
+    it('should render og:image', () => {
+      renderWithHelmet(<Seo title="Test" />);
+
+      expect(getMetaContent('property', 'og:image')).toBe('https://nextskip.io/og-image.svg');
+    });
+
+    it('should render og:type as website', () => {
+      renderWithHelmet(<Seo title="Test" />);
+
+      expect(getMetaContent('property', 'og:type')).toBe('website');
+    });
+
+    it('should use custom og:image when provided', () => {
+      renderWithHelmet(<Seo title="Test" ogImage="https://example.com/custom.png" />);
+
+      expect(getMetaContent('property', 'og:image')).toBe('https://example.com/custom.png');
+    });
+  });
+
+  describe('Twitter Card meta tags', () => {
+    it('should render twitter:card as summary_large_image', () => {
+      renderWithHelmet(<Seo title="Test" />);
+
+      expect(getMetaContent('name', 'twitter:card')).toBe('summary_large_image');
+    });
+
+    it('should render twitter:title', () => {
+      renderWithHelmet(<Seo title="Test" />);
+
+      expect(getMetaContent('name', 'twitter:title')).toBe('Test | NextSkip');
+    });
+
+    it('should render twitter:description', () => {
+      renderWithHelmet(<Seo title="Test" />);
+
+      const twitterDesc = getMetaContent('name', 'twitter:description');
+      expect(twitterDesc).toContain('amateur radio opportunities');
+    });
+
+    it('should render twitter:image', () => {
+      renderWithHelmet(<Seo title="Test" />);
+
+      expect(getMetaContent('name', 'twitter:image')).toBe('https://nextskip.io/og-image.svg');
+    });
+  });
+
+  describe('default description content', () => {
+    it('should mention key features in default description', () => {
+      renderWithHelmet(<Seo title="Test" />);
+
+      const description = getMetaContent('name', 'description');
+      expect(description).toContain('propagation');
+      expect(description).toContain('activations');
+      expect(description).toContain('contests');
+      expect(description).toContain('satellites');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements foundational SEO support for NextSkip as specified in #164.

- **Meta tags**: Title, description, canonical URL via `@dr.pogodin/react-helmet` (React 19 compatible)
- **Open Graph**: og:title, og:description, og:url, og:image, og:type for social sharing
- **Twitter Cards**: summary_large_image format for Twitter/X previews
- **Crawler files**: robots.txt and sitemap.xml for search engine guidance
- **OG image**: 1200x630 SVG using brand colors (indigo/cyan gradient)

### Files Added/Modified

| File | Change |
|------|--------|
| `package.json` | Added `@dr.pogodin/react-helmet` |
| `src/main/frontend/components/seo/` | New reusable Seo component |
| `src/main/frontend/index.tsx` | HelmetProvider wrapper |
| `src/main/frontend/views/DashboardView.tsx` | Uses Seo component |
| `src/main/resources/static/robots.txt` | Crawler guidance |
| `src/main/resources/static/sitemap.xml` | URL listing |
| `src/main/resources/static/og-image.svg` | Open Graph image |
| `src/test/frontend/components/seo/` | 17 test cases |

## Test plan

- [x] `npm run validate` passes (format, lint, 386 tests)
- [x] `./gradlew check` passes
- [ ] Verify page title shows "Amateur Radio Activity Dashboard | NextSkip"
- [ ] Verify meta tags in page source
- [ ] Access `/robots.txt` returns crawler guidance
- [ ] Access `/sitemap.xml` returns URL listing
- [ ] Access `/og-image.svg` displays brand image

Closes #164