### PR TITLE
fix(dashboard): suppress benign ResizeObserver loop errors

### DIFF
--- a/src/main/frontend/index.tsx
+++ b/src/main/frontend/index.tsx
@@ -6,6 +6,14 @@ import { HelmetProvider } from '@dr.pogodin/react-helmet';
 import App from './App';
 import './styles/global.css';
 
+// Suppress benign ResizeObserver loop errors
+// See: https://github.com/WICG/resize-observer/issues/38
+window.addEventListener('error', (e) => {
+  if (e.message === 'ResizeObserver loop completed with undelivered notifications.') {
+    e.stopImmediatePropagation();
+  }
+});
+
 const container = document.getElementById('outlet');
 const root = createRoot(container!);
 


### PR DESCRIPTION
## Summary
- Add global error handler to suppress `ResizeObserver loop completed with undelivered notifications` errors
- This error is caused by the masonry grid library's internal ResizeObserver conflicting with window resize events
- The error is a benign browser safety mechanism, not a bug - it prevents infinite loops but reports the defensive action

## Context
The error appears frequently in production due to the `@masonry-grid/react` library used in `ActivityGrid.tsx`. This is a [known issue](https://github.com/WICG/resize-observer/issues/38) with the ResizeObserver API and the standard solution is to suppress it at the global error handler level.

## Test plan
- [x] Frontend unit tests pass (396 tests)
- [ ] E2E tests (Playwright dependency issue in worktree, but unrelated to this change)
- [ ] Verify error no longer appears in browser console during resize operations