### PR TITLE
fix(dashboard): resolve Safari help modal rendering as thin line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,10 @@ jobs:
     needs: [backend, frontend-test]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
     permissions:
       contents: read
     steps:
@@ -186,10 +190,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install ${{ matrix.browser }} --with-deps
 
       - name: Start application in background
         run: |
@@ -199,7 +203,7 @@ jobs:
           timeout 180 bash -c 'until curl -sf http://localhost:8080/actuator/health > /dev/null; do sleep 2; done'
 
       - name: Run E2E tests
-        run: npx playwright test
+        run: npx playwright test --project=${{ matrix.browser }}
 
       - name: Stop application
         if: always()
@@ -212,7 +216,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: e2e-app-logs
+          name: e2e-app-logs-${{ matrix.browser }}
           path: app.log
           retention-days: 7
 
@@ -220,7 +224,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v6
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.browser }}
           path: build/playwright-reports/
           retention-days: 30
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,6 +32,8 @@ export default defineConfig({
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
   ],
   /* Start the app before running tests (local development only) */
   webServer: isCI ? undefined : {

--- a/src/main/frontend/components/help/HelpModal.css
+++ b/src/main/frontend/components/help/HelpModal.css
@@ -10,6 +10,7 @@
   background: transparent;
   max-width: min(90vw, 800px);
   max-height: 85vh;
+  height: 85vh; /* Explicit height for Safari - required for child percentage heights */
   width: 100%;
   margin: auto;
   overflow: visible;

--- a/src/test/e2e/help.spec.ts
+++ b/src/test/e2e/help.spec.ts
@@ -41,6 +41,22 @@ test.describe('Help System', () => {
     await expect(modal).toBeVisible();
   });
 
+  test('modal container has visible height', { timeout: 30_000 }, async ({ page }) => {
+    // Regression test for Safari CSS bug where modal showed as thin line
+    // due to percentage-based height without explicit parent height
+    await page.locator('.help-button').click();
+
+    const container = page.locator('.help-modal__container');
+    await expect(container).toBeVisible();
+
+    const box = await container.boundingBox();
+    expect(box).not.toBeNull();
+    if (box) {
+      // Container should have substantial height (not a thin line)
+      expect(box.height).toBeGreaterThan(200);
+    }
+  });
+
   test('modal displays correct title', { timeout: 30_000 }, async ({ page }) => {
     await page.locator('.help-button').click();
 


### PR DESCRIPTION
## Summary

- Fix Safari CSS bug where Help modal displayed as thin line instead of full modal
- Add cross-browser E2E testing with Firefox and WebKit (Safari engine)
- Run browser tests in parallel in CI for faster feedback

## Problem

In Safari, the Help modal appeared as a thin horizontal line rather than a proper modal. This was caused by `.help-modal__container` using `height: 100%` while the parent `<dialog>` element had no explicit height. Safari strictly requires parent heights for percentage-based children to calculate from, while Chrome/Firefox auto-size.

## Solution

Added `height: 85vh` to `.help-modal` (matching `max-height`), giving the child container an explicit parent height to calculate from.

## Cross-Browser Testing

To catch browser-specific bugs like this in the future:
- Added Firefox and WebKit projects to Playwright config
- Updated CI to run all 3 browsers in parallel using matrix strategy
- Added regression test that verifies modal has visible height (>200px)

## Test plan

- [ ] CI passes for all 3 browsers (chromium, firefox, webkit)
- [ ] Manually verify Help modal opens correctly in Safari