### PR TITLE
feat(help): add GitHub repository link to About section

### DIFF
--- a/src/main/frontend/components/help/AboutSection.tsx
+++ b/src/main/frontend/components/help/AboutSection.tsx
@@ -62,7 +62,18 @@ export function AboutSection() {
         </p>
 
         <h4>Open Source</h4>
-        <p>NextSkip is an open source project. Contributions, bug reports, and feature requests are welcome!</p>
+        <p>
+          NextSkip is an open source project. Contributions, bug reports, and feature requests are welcome! Visit the{' '}
+          <a
+            href="https://github.com/arunderwood/nextskip"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="help-section__link"
+          >
+            GitHub repository
+          </a>{' '}
+          to get involved.
+        </p>
       </div>
     </section>
   );


### PR DESCRIPTION
Add a clickable link to the NextSkip GitHub repository in the "Open Source"
section of the About modal to make it easier for users to contribute.