### PR TITLE
refactor: move business logic from endpoints to services (SRP)

### DIFF
--- a/src/main/java/io/nextskip/activations/api/ActivationsEndpoint.java
+++ b/src/main/java/io/nextskip/activations/api/ActivationsEndpoint.java
@@ -2,13 +2,8 @@ package io.nextskip.activations.api;
 
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import com.vaadin.hilla.BrowserCallable;
-import io.nextskip.activations.model.Activation;
-import io.nextskip.activations.model.ActivationsSummary;
-import io.nextskip.activations.model.ActivationType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 /**
  * Hilla endpoint for activations data (POTA/SOTA).
@@ -39,30 +34,6 @@ public class ActivationsEndpoint {
      */
     public ActivationsResponse getActivations() {
         LOG.debug("Fetching activations data for dashboard");
-
-        ActivationsSummary summary = activationsService.getActivationsSummary();
-
-        // Separate activations by type for the response
-        List<Activation> potaActivations = summary.activations().stream()
-                .filter(a -> a.type() == ActivationType.POTA)
-                .toList();
-
-        List<Activation> sotaActivations = summary.activations().stream()
-                .filter(a -> a.type() == ActivationType.SOTA)
-                .toList();
-
-        int totalCount = potaActivations.size() + sotaActivations.size();
-
-        ActivationsResponse response = new ActivationsResponse(
-                potaActivations,
-                sotaActivations,
-                totalCount,
-                summary.lastUpdated()
-        );
-
-        LOG.debug("Returning activations data: {} POTA, {} SOTA (total: {})",
-                potaActivations.size(), sotaActivations.size(), totalCount);
-
-        return response;
+        return activationsService.getActivationsResponse();
     }
 }

--- a/src/main/java/io/nextskip/activations/api/ActivationsService.java
+++ b/src/main/java/io/nextskip/activations/api/ActivationsService.java
@@ -16,4 +16,15 @@ public interface ActivationsService {
      * @return Summary of all current activations
      */
     ActivationsSummary getActivationsSummary();
+
+    /**
+     * Get activations data formatted for dashboard display.
+     *
+     * <p>Returns activations separated by type (POTA/SOTA) with metadata.
+     * This is the primary method for dashboard presentation, providing a
+     * complete response object ready for frontend consumption.
+     *
+     * @return ActivationsResponse with separated activation lists and metadata
+     */
+    ActivationsResponse getActivationsResponse();
 }

--- a/src/main/java/io/nextskip/contests/api/ContestEndpoint.java
+++ b/src/main/java/io/nextskip/contests/api/ContestEndpoint.java
@@ -2,14 +2,8 @@ package io.nextskip.contests.api;
 
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import com.vaadin.hilla.BrowserCallable;
-import io.nextskip.common.model.EventStatus;
-import io.nextskip.contests.model.Contest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.time.Duration;
-import java.time.Instant;
-import java.util.List;
 
 /**
  * Hilla endpoint for contest calendar data.
@@ -41,32 +35,6 @@ public class ContestEndpoint {
      */
     public ContestsResponse getContests() {
         LOG.debug("Fetching contest data for dashboard");
-
-        List<Contest> contests = contestService.getUpcomingContests();
-
-        // Calculate counts by status
-        int activeCount = (int) contests.stream()
-                .filter(c -> c.getStatus() == EventStatus.ACTIVE)
-                .count();
-
-        int upcomingCount = (int) contests.stream()
-                .filter(c -> c.getStatus() == EventStatus.UPCOMING)
-                .filter(c -> c.getTimeRemaining().compareTo(Duration.ofHours(24)) <= 0)
-                .count();
-
-        int totalCount = contests.size();
-
-        ContestsResponse response = new ContestsResponse(
-                contests,
-                activeCount,
-                upcomingCount,
-                totalCount,
-                Instant.now()
-        );
-
-        LOG.debug("Returning contest data: {} active, {} upcoming soon, {} total",
-                activeCount, upcomingCount, totalCount);
-
-        return response;
+        return contestService.getContestsResponse();
     }
 }

--- a/src/main/java/io/nextskip/contests/api/ContestService.java
+++ b/src/main/java/io/nextskip/contests/api/ContestService.java
@@ -22,4 +22,15 @@ public interface ContestService {
      * @return List of upcoming contests, or empty list if unavailable
      */
     List<Contest> getUpcomingContests();
+
+    /**
+     * Get upcoming contest data formatted for dashboard display.
+     *
+     * <p>Returns contests with pre-calculated counts by status. This is the
+     * primary method for dashboard presentation, providing a complete response
+     * object ready for frontend consumption.
+     *
+     * @return ContestsResponse with upcoming contests and metadata
+     */
+    ContestsResponse getContestsResponse();
 }

--- a/src/main/java/io/nextskip/propagation/api/PropagationEndpoint.java
+++ b/src/main/java/io/nextskip/propagation/api/PropagationEndpoint.java
@@ -38,16 +38,7 @@ public class PropagationEndpoint {
      */
     public PropagationResponse getPropagationData() {
         LOG.debug("Fetching propagation data for dashboard");
-
-        SolarIndices solarIndices = propagationService.getCurrentSolarIndices();
-        List<BandCondition> bandConditions = propagationService.getBandConditions();
-
-        PropagationResponse response = new PropagationResponse(solarIndices, bandConditions);
-
-        LOG.debug("Returning propagation data: {} band conditions",
-                  bandConditions != null ? bandConditions.size() : 0);
-
-        return response;
+        return propagationService.getPropagationResponse();
     }
 
     /**

--- a/src/main/java/io/nextskip/propagation/api/PropagationService.java
+++ b/src/main/java/io/nextskip/propagation/api/PropagationService.java
@@ -50,4 +50,15 @@ public interface PropagationService {
      * @return Mono of band conditions list
      */
     Mono<List<BandCondition>> getBandConditionsReactive();
+
+    /**
+     * Get propagation data formatted for dashboard display.
+     *
+     * <p>Returns solar indices and band conditions combined in a response object.
+     * This is the primary method for dashboard presentation, providing a complete
+     * response object ready for frontend consumption.
+     *
+     * @return PropagationResponse with solar indices and band conditions
+     */
+    PropagationResponse getPropagationResponse();
 }

--- a/src/main/java/io/nextskip/propagation/internal/PropagationServiceImpl.java
+++ b/src/main/java/io/nextskip/propagation/internal/PropagationServiceImpl.java
@@ -1,6 +1,7 @@
 package io.nextskip.propagation.internal;
 
 import io.nextskip.common.model.FrequencyBand;
+import io.nextskip.propagation.api.PropagationResponse;
 import io.nextskip.propagation.api.PropagationService;
 import io.nextskip.propagation.model.BandCondition;
 import io.nextskip.propagation.model.SolarIndices;
@@ -121,5 +122,20 @@ public class PropagationServiceImpl implements PropagationService {
     @Override
     public Mono<List<BandCondition>> getBandConditionsReactive() {
         return Mono.fromCallable(this::getBandConditions);
+    }
+
+    @Override
+    public PropagationResponse getPropagationResponse() {
+        LOG.debug("Building propagation response for dashboard");
+
+        SolarIndices solarIndices = getCurrentSolarIndices();
+        List<BandCondition> bandConditions = getBandConditions();
+
+        PropagationResponse response = new PropagationResponse(solarIndices, bandConditions);
+
+        LOG.debug("Returning propagation response: {} band conditions",
+                bandConditions != null ? bandConditions.size() : 0);
+
+        return response;
     }
 }

--- a/src/test/java/io/nextskip/contests/api/ContestEndpointTest.java
+++ b/src/test/java/io/nextskip/contests/api/ContestEndpointTest.java
@@ -1,0 +1,126 @@
+package io.nextskip.contests.api;
+
+import io.nextskip.contests.model.Contest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for ContestEndpoint.
+ *
+ * <p>Since the endpoint is now a thin delegate to the service layer,
+ * these tests verify that the endpoint correctly delegates to the service
+ * and returns the service's response unchanged.
+ */
+@ExtendWith(MockitoExtension.class)
+class ContestEndpointTest {
+
+    @Mock
+    private ContestService contestService;
+
+    private ContestEndpoint endpoint;
+
+    @BeforeEach
+    void setUp() {
+        endpoint = new ContestEndpoint(contestService);
+    }
+
+    @Test
+    void testGetContests_DelegatesToService() {
+        // Given: Service returns response with contests
+        Instant now = Instant.now();
+        List<Contest> contests = List.of(
+                createContest("ARRL 10-Meter Contest", now.plus(1, ChronoUnit.HOURS)),
+                createContest("CQ WW DX CW", now.plus(48, ChronoUnit.HOURS))
+        );
+        ContestsResponse serviceResponse = new ContestsResponse(
+                contests, 0, 1, 2, now);
+
+        when(contestService.getContestsResponse()).thenReturn(serviceResponse);
+
+        // When
+        ContestsResponse response = endpoint.getContests();
+
+        // Then: Should return service response unchanged
+        assertNotNull(response);
+        assertEquals(2, response.contests().size());
+        assertEquals(0, response.activeCount());
+        assertEquals(1, response.upcomingCount());
+        assertEquals(2, response.totalCount());
+        assertEquals(now, response.lastUpdated());
+
+        verify(contestService).getContestsResponse();
+    }
+
+    @Test
+    void testGetContests_EmptyList() {
+        // Given: Service returns empty response
+        Instant now = Instant.now();
+        ContestsResponse serviceResponse = new ContestsResponse(
+                List.of(), 0, 0, 0, now);
+
+        when(contestService.getContestsResponse()).thenReturn(serviceResponse);
+
+        // When
+        ContestsResponse response = endpoint.getContests();
+
+        // Then
+        assertNotNull(response);
+        assertTrue(response.contests().isEmpty());
+        assertEquals(0, response.totalCount());
+
+        verify(contestService).getContestsResponse();
+    }
+
+    @Test
+    void testGetContests_WithActiveContests() {
+        // Given: Service returns response with active contests
+        Instant now = Instant.now();
+        List<Contest> contests = List.of(
+                createContest("Active Contest", now.minus(1, ChronoUnit.HOURS))
+        );
+        ContestsResponse serviceResponse = new ContestsResponse(
+                contests, 1, 0, 1, now);
+
+        when(contestService.getContestsResponse()).thenReturn(serviceResponse);
+
+        // When
+        ContestsResponse response = endpoint.getContests();
+
+        // Then
+        assertNotNull(response);
+        assertEquals(1, response.activeCount());
+        assertEquals(0, response.upcomingCount());
+
+        verify(contestService).getContestsResponse();
+    }
+
+    /**
+     * Helper method to create a test contest.
+     */
+    private Contest createContest(String name, Instant startTime) {
+        return new Contest(
+                name,
+                startTime,
+                startTime.plus(48, ChronoUnit.HOURS),
+                Set.of(),
+                Set.of(),
+                null,
+                "https://contestcalendar.com/test",
+                null
+        );
+    }
+}

--- a/src/test/java/io/nextskip/propagation/api/PropagationEndpointTest.java
+++ b/src/test/java/io/nextskip/propagation/api/PropagationEndpointTest.java
@@ -61,11 +61,16 @@ class PropagationEndpointTest {
 
     @Test
     void shouldGet_PropagationData_Success() {
-        when(propagationService.getCurrentSolarIndices()).thenReturn(testSolarIndices);
-        when(propagationService.getBandConditions()).thenReturn(testBandConditions);
+        // Given: Service returns response with solar indices and band conditions
+        PropagationResponse serviceResponse = new PropagationResponse(
+                testSolarIndices, testBandConditions);
 
+        when(propagationService.getPropagationResponse()).thenReturn(serviceResponse);
+
+        // When
         PropagationResponse response = endpoint.getPropagationData();
 
+        // Then
         assertNotNull(response);
         assertNotNull(response.solarIndices());
         assertNotNull(response.bandConditions());
@@ -74,57 +79,68 @@ class PropagationEndpointTest {
         assertEquals(150.5, response.solarIndices().solarFluxIndex(), 0.01);
         assertEquals(5, response.bandConditions().size());
 
-        verify(propagationService).getCurrentSolarIndices();
-        verify(propagationService).getBandConditions();
+        verify(propagationService).getPropagationResponse();
     }
 
     @Test
     void shouldGet_PropagationData_NullSolarIndices() {
-        when(propagationService.getCurrentSolarIndices()).thenReturn(null);
-        when(propagationService.getBandConditions()).thenReturn(testBandConditions);
+        // Given: Service returns response with null solar indices
+        PropagationResponse serviceResponse = new PropagationResponse(
+                null, testBandConditions);
 
+        when(propagationService.getPropagationResponse()).thenReturn(serviceResponse);
+
+        // When
         PropagationResponse response = endpoint.getPropagationData();
 
+        // Then
         assertNotNull(response);
         assertNull(response.solarIndices());
         assertNotNull(response.bandConditions());
         assertEquals(5, response.bandConditions().size());
 
-        verify(propagationService).getCurrentSolarIndices();
-        verify(propagationService).getBandConditions();
+        verify(propagationService).getPropagationResponse();
     }
 
     @Test
     void shouldGet_PropagationData_EmptyBandConditions() {
-        when(propagationService.getCurrentSolarIndices()).thenReturn(testSolarIndices);
-        when(propagationService.getBandConditions()).thenReturn(List.of());
+        // Given: Service returns response with empty band conditions
+        PropagationResponse serviceResponse = new PropagationResponse(
+                testSolarIndices, List.of());
 
+        when(propagationService.getPropagationResponse()).thenReturn(serviceResponse);
+
+        // When
         PropagationResponse response = endpoint.getPropagationData();
 
+        // Then
         assertNotNull(response);
         assertNotNull(response.solarIndices());
         assertNotNull(response.bandConditions());
         assertTrue(response.bandConditions().isEmpty());
 
-        verify(propagationService).getCurrentSolarIndices();
-        verify(propagationService).getBandConditions();
+        verify(propagationService).getPropagationResponse();
     }
 
     @Test
     void shouldGet_PropagationData_BothNull() {
-        when(propagationService.getCurrentSolarIndices()).thenReturn(null);
-        when(propagationService.getBandConditions()).thenReturn(null);
+        // Given: Service returns response with null solar indices and null band conditions
+        PropagationResponse serviceResponse = new PropagationResponse(
+                null, null);
 
+        when(propagationService.getPropagationResponse()).thenReturn(serviceResponse);
+
+        // When
         PropagationResponse response = endpoint.getPropagationData();
 
+        // Then
         assertNotNull(response);
         assertNull(response.solarIndices());
         // Defensive copying converts null to empty list
         assertNotNull(response.bandConditions());
         assertTrue(response.bandConditions().isEmpty());
 
-        verify(propagationService).getCurrentSolarIndices();
-        verify(propagationService).getBandConditions();
+        verify(propagationService).getPropagationResponse();
     }
 
     @Test
@@ -184,18 +200,24 @@ class PropagationEndpointTest {
     }
 
     @Test
-    void shouldReturn_ResponseTimestamp() throws InterruptedException {
-        when(propagationService.getCurrentSolarIndices()).thenReturn(testSolarIndices);
-        when(propagationService.getBandConditions()).thenReturn(testBandConditions);
-
+    void shouldReturn_ResponseTimestamp() {
+        // Given: Service returns response with timestamp set
         Instant before = Instant.now();
-        Thread.sleep(10); // Small delay to ensure timestamp difference
-        PropagationResponse response = endpoint.getPropagationData();
+        PropagationResponse serviceResponse = new PropagationResponse(
+                testSolarIndices, testBandConditions);
         Instant after = Instant.now();
 
+        when(propagationService.getPropagationResponse()).thenReturn(serviceResponse);
+
+        // When
+        PropagationResponse response = endpoint.getPropagationData();
+
+        // Then: Endpoint passes through the service's timestamp
         assertNotNull(response.timestamp());
-        assertTrue(response.timestamp().isAfter(before));
-        assertTrue(response.timestamp().isBefore(after));
+        assertFalse(response.timestamp().isBefore(before));
+        assertFalse(response.timestamp().isAfter(after));
+
+        verify(propagationService).getPropagationResponse();
     }
 
     @Test


### PR DESCRIPTION
Move data filtering, aggregation, and response construction logic from
presentation layer (endpoints) to business logic layer (services).

SOLID Compliance:
- Single Responsibility: Endpoints now only handle RPC, services handle business logic
- Open-Closed: Can extend filtering logic without modifying endpoints
- Dependency Inversion: Endpoints depend on service abstractions

Changes:
- ContestService: Add getContestsResponse() with filtering/counting logic
- ActivationsService: Add getActivationsResponse() with type-based filtering
- PropagationService: Add getPropagationResponse() for consistency
- All endpoints: Refactored to thin delegates (single-line service calls)

Benefits:
- Consistent pattern across all three modules
- Business logic testable at service layer
- Easier maintenance (changes isolated to service layer)
- Prepares for future caching at client layer

Addresses tech debt: SOLID principle violations in endpoint layer