### PR TITLE
chore(analytics): disable PostHog proxy, send directly to PostHog

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -2,4 +2,4 @@ VITE_FARO_COLLECTOR_URL=https://faro-collector-prod-us-west-0.grafana.net/collec
 VITE_TRACE_CORS_URLS=nextskip\.io
 VITE_ENVIRONMENT=production
 VITE_POSTHOG_KEY=phc_hl6zyotnK4K6I7PJV3oWCMTkGdyZ2GmgQ9n27PW8yZb
-VITE_POSTHOG_HOST=https://a.nextskip.io
+VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,6 +120,6 @@ vaadin:
 # PostHog Analytics Proxy Configuration
 posthog:
   proxy:
-    enabled: true
+    enabled: false
     ingest-url: https://us.i.posthog.com
     assets-url: https://us-assets.i.posthog.com


### PR DESCRIPTION
## Summary

- Disable the PostHog reverse proxy (`posthog.proxy.enabled: false`)
- Configure frontend to send analytics directly to PostHog's US ingest endpoint (`us.i.posthog.com`)

The `a.nextskip.io` proxy subdomain is not yet configured with proper CORS headers. This change bypasses the proxy until infrastructure is ready.

## Test plan

- [ ] Deploy to production
- [ ] Verify analytics events appear in PostHog dashboard
- [ ] Confirm no CORS errors in browser console