### PR TITLE
perf: optimize JVM memory for 512MB container

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,10 +11,18 @@ server:
         same-site: lax
         secure: true
         http-only: true
+  # Memory optimization: Reduce thread pool (default 200 threads × 1MB = 200MB)
+  tomcat:
+    threads:
+      max: 20
+      min-spare: 2
 
 spring:
   application:
     name: nextskip
+  # Memory optimization: Delay bean creation until first use
+  main:
+    lazy-initialization: true
   # Static resource caching for PWA
   web:
     resources:
@@ -30,8 +38,9 @@ spring:
     password: ${DATABASE_PASSWORD:nextskip}
     driver-class-name: org.postgresql.Driver
     hikari:
-      maximum-pool-size: 10
-      minimum-idle: 2
+      # Memory optimization: Reduce pool size (each connection uses memory)
+      maximum-pool-size: 3
+      minimum-idle: 1
       connection-timeout: 30000
       idle-timeout: 600000
       max-lifetime: 1800000


### PR DESCRIPTION
## Summary
- Fixes OOM errors on Render's 512MB Starter plan by optimizing JVM memory settings
- Caps Metaspace (160MB), CodeCache (64MB), and reduces heap percentage
- Reduces thread overhead: Tomcat (200→20), HikariCP (10→3), stack size (1MB→256KB)
- Staggers data refresh timing to prevent concurrent memory spikes

## Root Cause
Pyroscope and Prometheus metrics showed memory spiking from ~265MB baseline to ~916MB during data refresh cycles. Metaspace was unbounded at 152MB.

## Expected Impact
Peak memory reduced from ~700MB to ~485MB (under 512MB container limit).

## Test Plan
- [x] Build passes locally
- [ ] Deploy to Render and monitor via Grafana
- [ ] Verify no OOM in Render logs
- [ ] Confirm memory stays under limits during data refresh