### PR TITLE
build(gradle): add retry support for agent downloads

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.spring.dependency.management)
     alias(libs.plugins.vaadin)
+    alias(libs.plugins.download)
 
     // Code quality plugins
     id 'checkstyle'
@@ -136,43 +137,29 @@ dependencies {
 // OpenTelemetry agent configuration
 def otelAgentVersion = libs.versions.grafana.otel.agent.get()
 def otelAgentDir = layout.buildDirectory.dir("otel-agent")
-def otelAgentJar = otelAgentDir.map { it.file("grafana-opentelemetry-java.jar") }
 
-tasks.register('downloadOtelAgent') {
+tasks.register('downloadOtelAgent', Download) {
     description = 'Downloads the Grafana OpenTelemetry Java agent'
     group = 'observability'
 
-    outputs.file(otelAgentJar)
-
-    doLast {
-        def agentUrl = "https://github.com/grafana/grafana-opentelemetry-java/releases/download/v${otelAgentVersion}/grafana-opentelemetry-java.jar"
-        def destFile = otelAgentJar.get().asFile
-        destFile.parentFile.mkdirs()
-
-        ant.get(src: agentUrl, dest: destFile, skipexisting: false)
-        println "Downloaded Grafana OTEL agent v${otelAgentVersion} to ${destFile}"
-    }
+    src "https://github.com/grafana/grafana-opentelemetry-java/releases/download/v${otelAgentVersion}/grafana-opentelemetry-java.jar"
+    dest otelAgentDir.map { it.file("grafana-opentelemetry-java.jar") }
+    overwrite false
+    retries 3
 }
 
 // Pyroscope profiling agent configuration
 def pyroscopeAgentVersion = libs.versions.pyroscope.agent.get()
 def pyroscopeAgentDir = layout.buildDirectory.dir("pyroscope-agent")
-def pyroscopeAgentJar = pyroscopeAgentDir.map { it.file("pyroscope.jar") }
 
-tasks.register('downloadPyroscopeAgent') {
+tasks.register('downloadPyroscopeAgent', Download) {
     description = 'Downloads the Pyroscope Java profiling agent'
     group = 'observability'
 
-    outputs.file(pyroscopeAgentJar)
-
-    doLast {
-        def agentUrl = "https://github.com/grafana/pyroscope-java/releases/download/v${pyroscopeAgentVersion}/pyroscope.jar"
-        def destFile = pyroscopeAgentJar.get().asFile
-        destFile.parentFile.mkdirs()
-
-        ant.get(src: agentUrl, dest: destFile, skipexisting: false)
-        println "Downloaded Pyroscope agent v${pyroscopeAgentVersion} to ${destFile}"
-    }
+    src "https://github.com/grafana/pyroscope-java/releases/download/v${pyroscopeAgentVersion}/pyroscope.jar"
+    dest pyroscopeAgentDir.map { it.file("pyroscope.jar") }
+    overwrite false
+    retries 3
 }
 
 tasks.named('test') {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,9 @@ spring-dependency-management = "1.1.7"
 grafana-otel-agent = "2.22.0"
 pyroscope-agent = "2.1.2"
 
+# Build utilities
+download-plugin = "5.6.0"
+
 # Quality & testing tools
 # NOTE: checkstyle, pmd, spotbugs-tool, and jacoco versions moved to direct literals in build.gradle
 # to enable Renovate detection. See: https://github.com/renovatebot/renovate/discussions/40147
@@ -33,6 +36,7 @@ spring-dependency-management = { id = "io.spring.dependency-management", version
 vaadin = { id = "com.vaadin", version.ref = "vaadin" }
 spotbugs = { id = "com.github.spotbugs", version.ref = "spotbugs-plugin" }
 pitest = { id = "info.solidsoft.pitest", version.ref = "pitest" }
+download = { id = "de.undercouch.download", version.ref = "download-plugin" }
 
 [libraries]
 # Vaadin with Hilla


### PR DESCRIPTION
## Summary
- Add gradle-download-task plugin (v5.6.0) for resilient file downloads
- Refactor agent download tasks to use plugin with built-in retry support
- Configure 3 retries for OpenTelemetry and Pyroscope agent downloads

## Why
CI builds occasionally fail due to transient network issues when downloading agents from GitHub releases. The gradle-download-task plugin provides production-ready retry logic.

## Test plan
- [x] `./gradlew downloadOtelAgent downloadPyroscopeAgent` succeeds
- [x] Configuration cache works correctly
- [x] Full build passes