### PR TITLE
fix(perf): remove lazy-init causing OOM on first request

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,9 +20,6 @@ server:
 spring:
   application:
     name: nextskip
-  # Memory optimization: Delay bean creation until first use
-  main:
-    lazy-initialization: true
   # Static resource caching for PWA
   web:
     resources:


### PR DESCRIPTION
## Summary
Removes `spring.main.lazy-initialization` which was causing OOM crashes when users visited the site.

## Root Cause
Lazy initialization defers bean creation until first request. When a request arrived:
- Multiple beans initialized simultaneously  
- Metaspace spiked from 197 MB to **397 MB**
- Total memory exceeded 512 MB container limit → OOM

## Evidence
```
Before crash:  74 MB heap + 197 MB non-heap = 271 MB ✅
During crash: 197 MB heap + 397 MB non-heap = 594 MB 💥
```

## Test Plan
- [x] Build passes locally
- [ ] Deploy and verify no OOM on first request
- [ ] Monitor memory via Grafana