### PR TITLE
chore(infra): tune JVM and app settings for 2GB instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,18 +34,18 @@ COPY --from=builder /app/build/otel-agent/grafana-opentelemetry-java.jar otel-ag
 COPY --from=builder /app/build/pyroscope-agent/pyroscope.jar pyroscope-agent.jar
 
 # Distroless runs as non-root by default (uid 65532)
-# JVM memory optimizations for 512MB container (distroless doesn't support JAVA_OPTS)
-# - MaxRAMPercentage=50.0: ~256MB heap leaves room for metaspace + agents
-# - MaxMetaspaceSize=160m: Cap metaspace growth (baseline ~152MB)
-# - ReservedCodeCacheSize=64m: Limit CodeHeap (baseline ~36MB)
-# - UseSerialGC: Lower overhead than G1 for small heaps
-# - Xss256k: Reduce thread stack from 1MB to 256KB
+# JVM settings for 2GB container (distroless doesn't support JAVA_OPTS)
+# - MaxRAMPercentage=60.0: ~1.2GB heap with room for metaspace + agents
+# - MaxMetaspaceSize=256m: Headroom for Hibernate/Spring class loading
+# - ReservedCodeCacheSize=128m: Room for JIT compilation
+# - G1GC: Better throughput than SerialGC for larger heaps
+# - Xss512k: Comfortable thread stack size
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport \
-  -XX:MaxRAMPercentage=50.0 \
-  -XX:MaxMetaspaceSize=160m \
-  -XX:ReservedCodeCacheSize=64m \
-  -XX:+UseSerialGC \
-  -Xss256k"
+  -XX:MaxRAMPercentage=60.0 \
+  -XX:MaxMetaspaceSize=256m \
+  -XX:ReservedCodeCacheSize=128m \
+  -XX:+UseG1GC \
+  -Xss512k"
 
 EXPOSE 8080
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,11 +11,10 @@ server:
         same-site: lax
         secure: true
         http-only: true
-  # Memory optimization: Reduce thread pool (default 200 threads × 1MB = 200MB)
   tomcat:
     threads:
-      max: 20
-      min-spare: 2
+      max: 50
+      min-spare: 5
 
 spring:
   application:
@@ -35,9 +34,8 @@ spring:
     password: ${DATABASE_PASSWORD:nextskip}
     driver-class-name: org.postgresql.Driver
     hikari:
-      # Memory optimization: Reduce pool size (each connection uses memory)
-      maximum-pool-size: 3
-      minimum-idle: 1
+      maximum-pool-size: 10
+      minimum-idle: 2
       connection-timeout: 30000
       idle-timeout: 600000
       max-lifetime: 1800000


### PR DESCRIPTION
## Summary

- Adjust JVM settings for Render Standard instance (2GB memory)
- Increase Tomcat thread pool for better concurrency
- Expand HikariCP connection pool for database headroom

## Changes

### Dockerfile (JVM Settings)
| Setting | 512MB | 2GB | Rationale |
|---------|-------|-----|-----------|
| MaxRAMPercentage | 50% | 60% | ~1.2GB heap with room for metaspace + agents |
| MaxMetaspaceSize | 160m | 256m | Headroom for Hibernate/Spring class loading |
| ReservedCodeCacheSize | 64m | 128m | Room for JIT compilation |
| GC | SerialGC | G1GC | Better throughput for larger heaps |
| Thread Stack | 256k | 512k | Comfortable stack size |

### application.yml (App Settings)
| Setting | 512MB | 2GB | Rationale |
|---------|-------|-----|-----------|
| Tomcat max threads | 20 | 50 | Handle more concurrent requests |
| Tomcat min-spare | 2 | 5 | Faster response to traffic spikes |
| HikariCP max pool | 3 | 10 | More database connections |
| HikariCP min-idle | 1 | 2 | Reduce connection warmup latency |

## Test plan

- [ ] Deploy to Render Standard instance
- [ ] Verify application starts successfully
- [ ] Monitor memory usage stays within 2GB
- [ ] Verify no OOM errors under normal load