### PR TITLE
fix(observability): add VITE_ENVIRONMENT to Vite define block

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -98,6 +98,7 @@ const customConfig: UserConfigFn = (env) => {
       'import.meta.env.VITE_FARO_COLLECTOR_URL': JSON.stringify(envVars.VITE_FARO_COLLECTOR_URL || ''),
       'import.meta.env.VITE_TRACE_CORS_URLS': JSON.stringify(envVars.VITE_TRACE_CORS_URLS || ''),
       'import.meta.env.VITE_APP_VERSION': JSON.stringify(envVars.VITE_APP_VERSION || ''),
+      'import.meta.env.VITE_ENVIRONMENT': JSON.stringify(envVars.VITE_ENVIRONMENT || 'development'),
       'import.meta.env.VITE_POSTHOG_KEY': JSON.stringify(envVars.VITE_POSTHOG_KEY || ''),
       'import.meta.env.VITE_POSTHOG_HOST': JSON.stringify(envVars.VITE_POSTHOG_HOST || ''),
     },


### PR DESCRIPTION
## Summary

- Adds `VITE_ENVIRONMENT` to the Vite `define` block in `vite.config.ts`

## Problem

Frontend telemetry was incorrectly labeled as `development` in production because `VITE_ENVIRONMENT` wasn't being passed through the Vite build. The env var was set in `.env.production`, but the explicit `define` block in `vite.config.ts` didn't include it.

## Solution

Add the missing env var mapping to the `define` block so it gets inlined into the frontend build.

## Verification

After deploy, check Grafana Cloud:
```
{service_name="nextskip-frontend", deployment_environment="production"}
```

Should now return production frontend logs instead of empty results.