### PR TITLE
fix(observability): move actuator to internal port 9090

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,6 +120,8 @@ resilience4j:
 
 # Actuator Configuration
 management:
+  server:
+    port: 9090  # Render only exposes PORT env var; keeps metrics off public internet
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
## Summary

- Move Spring Boot Actuator endpoints to port 9090 (internal only)
- Render only exposes the `PORT` env var publicly, so port 9090 is not accessible from the internet
- Grafana agent continues scraping metrics via `localhost:9090`

## Problem

Actuator endpoints (`/actuator/health`, `/actuator/metrics`, `/actuator/prometheus`) were publicly exposed at `nextskip.io/actuator`, leaking operational data:
- Database connection pool details
- JVM memory/GC metrics
- Cache names and statistics
- HTTP request patterns

## Test Plan

- [ ] Verify build passes
- [ ] After deploy: `curl https://nextskip.io/actuator` returns 404 or Vaadin SPA
- [ ] Verify Grafana Cloud still receives metrics