### PR TITLE
fix(observability): add /health endpoint for Render load balancer

### DIFF
--- a/src/main/java/io/nextskip/config/HealthController.java
+++ b/src/main/java/io/nextskip/config/HealthController.java
@@ -1,0 +1,26 @@
+package io.nextskip.config;
+
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Health endpoint for Render load balancer checks.
+ *
+ * <p>Render can only health-check the main exposed port (8080). Actuator runs on port 9090
+ * for security, so this provides a simple liveness check on the public port.
+ */
+@RestController
+public class HealthController {
+
+    /**
+     * Returns basic health status for load balancer checks.
+     *
+     * @return health status map
+     */
+    @GetMapping("/health")
+    public Map<String, String> health() {
+        return Map.of("status", "UP");
+    }
+}


### PR DESCRIPTION
## Summary

- Add simple `/health` endpoint on port 8080 for Render load balancer checks
- Complements PR #215 which moved actuator to port 9090

## Problem

Render can only health-check the main exposed port (8080). After #215, actuator runs on port 9090, so Render has no health endpoint to check.

## Solution

Add a lightweight `/health` endpoint returning `{"status":"UP"}` on port 8080.

Detailed health monitoring (DB, cache, disk) remains available via Grafana agent scraping `localhost:9090/actuator/health`.

## Test Plan

- [ ] Build passes
- [ ] After deploy: `curl https://nextskip.io/health` returns `{"status":"UP"}`
- [ ] Render health checks pass