### PR TITLE
feat(commands): add /work-issue command for issue-to-plan workflow

### DIFF
--- a/.claude/commands/work-issue.md
+++ b/.claude/commands/work-issue.md
@@ -1,0 +1,59 @@
+---
+description: Review GitHub issue and create implementation plan following SOLID principles
+argument-hint: <issue-number-or-url> [additional guidance]
+allowed-tools: Read, Grep, Glob, Bash(git *), Task, AskUserQuestion, mcp__github__issue_read, mcp__github__get_file_contents
+---
+
+# Work Issue: $ARGUMENTS
+
+## Workflow
+
+### 1. Fetch Issue
+
+Parse `$1` as either issue number or full GitHub URL. Use GitHub MCP tools to retrieve the issue content, labels, and comments.
+
+### 2. Explore Codebase
+
+Launch Explore agents to understand:
+- Files/packages mentioned in the issue
+- Related existing implementations
+- Current patterns and conventions
+
+Compare the issue's implementation details against current codebase state.
+
+### 3. Research Alternatives
+
+If `$ARGUMENTS` includes questions about alternatives or approaches, research and compare options considering project conventions.
+
+### 4. Clarify
+
+Ask clarifying questions about ambiguous requirements or implementation choices before planning.
+
+### 5. Create Plan
+
+Enter **planning mode** to create an implementation plan that:
+
+- Follows CLAUDE.md best practices and existing patterns
+- Adheres to SOLID principles
+- Includes testing strategy (unit, integration, E2E per `/plan-tests`)
+- Includes documentation updates
+
+## Output
+
+```
+## Issue Review: #{number} - {title}
+
+### Summary
+{Intent and proposed implementation}
+
+### Codebase Analysis
+{Current state, alignment with issue, any gaps}
+
+### Questions
+{Clarifying questions before proceeding}
+
+---
+
+## Implementation Plan
+{Steps with specific files, testing plan, documentation}
+```


### PR DESCRIPTION
## Summary

- Adds new `/work-issue` slash command that streamlines the workflow from GitHub issue review to implementation planning
- Accepts issue number or full URL, plus optional guidance for researching alternatives
- Generates implementation plans following SOLID principles and project best practices

## Usage

```
/work-issue 194
/work-issue https://github.com/arunderwood/nextskip/issues/194
/work-issue 194 Research caching alternatives
```

## Test plan

- [ ] Invoke `/work-issue` with an issue number
- [ ] Invoke `/work-issue` with a full GitHub URL
- [ ] Verify command appears in `/help` output