### PR TITLE
chore(docker): exclude dev-only files from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,3 +36,20 @@ src/test/e2e/
 playwright-report/
 test-results/
 coverage/
+
+# Docker Compose (local development only)
+docker-compose.yml
+docker-compose*.yml
+
+# CI/CD configs
+codecov.yml
+
+# Code formatting (dev-only)
+.prettierrc
+.prettierignore
+
+# Lint/test configs (not needed for production JAR build)
+eslint.config.js
+vitest.config.ts
+playwright.config.ts
+tsconfig.node.json


### PR DESCRIPTION
## Summary
- Add exclusions for dev-only files not needed in production Docker image
- Reduces build context size and keeps production image clean

## Changes
Added to `.dockerignore`:
- `docker-compose.yml` / `docker-compose*.yml` - local dev database
- `codecov.yml` - CI config
- `.prettierrc` / `.prettierignore` - formatter configs  
- `eslint.config.js`, `vitest.config.ts`, `playwright.config.ts` - lint/test configs
- `tsconfig.node.json` - build tooling config

## Test plan
- [x] Docker build succeeds
- [x] Container starts and responds with HTTP 200
- [x] All backend tests pass
- [x] All frontend tests pass (394 passing)
- [x] E2E tests pass (86/87, 1 flaky)