### PR TITLE
docs(persistence): add reference for new data source integrations

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -2,6 +2,8 @@
 
 NextSkip uses PostgreSQL 18 for persistent data storage.
 
+> **Adding a new data source?** See [PERSISTENCE_REFERENCE.md](PERSISTENCE_REFERENCE.md) for reference examples.
+
 ## Local Development
 
 ### Docker Compose (Recommended)

--- a/docs/PERSISTENCE_REFERENCE.md
+++ b/docs/PERSISTENCE_REFERENCE.md
@@ -1,0 +1,46 @@
+# Persistence Reference
+
+Quick reference for adding data source integrations with persistence.
+
+## Architecture
+
+```
+External API → db-scheduler task → Database → cache.refresh("all")
+                                                      ↓
+Browser ← @BrowserCallable ← Service ← LoadingCache ← DB
+```
+
+## Reference Examples
+
+| Component | Reference File | Key Pattern |
+|-----------|----------------|-------------|
+| Domain Model | `propagation/model/SolarIndices.java` | Immutable Java record |
+| Entity (simple) | `propagation/persistence/entity/SolarIndicesEntity.java` | `fromDomain()` / `toDomain()` |
+| Entity (complex) | `activations/persistence/entity/ActivationEntity.java` | Polymorphic flattening |
+| Entity (collections) | `contests/persistence/entity/ContestEntity.java` | `@ElementCollection` |
+| Repository | `propagation/persistence/repository/SolarIndicesRepository.java` | Spring Data JPA |
+| Migration | `db/changelog/migrations/002-solar-indices-table.yaml` | Liquibase YAML |
+| Refresh Task | `propagation/internal/scheduler/NoaaRefreshTask.java` | db-scheduler `RecurringTask` |
+| Cache Config | `common/config/CacheConfig.java` | Caffeine `LoadingCache` |
+| Endpoint | `propagation/api/PropagationEndpoint.java` | `@BrowserCallable` |
+
+All paths relative to `src/main/java/io/nextskip/` (or `src/main/resources/` for migrations).
+
+## Conventions
+
+**Migration naming:** `XXX-description.yaml` (zero-padded sequence, e.g., `008-my-table.yaml`)
+
+**Task naming:** `<module>-refresh` or `<source>-refresh` (e.g., `noaa-refresh`, `pota-refresh`)
+
+**Cache key:** Use `CacheConfig.CACHE_KEY` (`"all"`) for single-list caches
+
+## Checklist
+
+- [ ] Domain model is immutable (Java record)
+- [ ] Entity has `fromDomain()` and `toDomain()` converters
+- [ ] Entity has `protected` no-arg constructor
+- [ ] Migration follows naming convention
+- [ ] Refresh task uses `@Transactional` and throws `DataRefreshException`
+- [ ] `LoadingCache` bean added to `CacheConfig`
+- [ ] Endpoint uses `@BrowserCallable` and `@AnonymousAllowed`
+- [ ] Unit tests for entity converters and refresh task


### PR DESCRIPTION
## Summary

Add concise reference pointing to canonical source files for adding data source integrations with persistence.

Reference-style documentation (46 lines) instead of instructional guide - stays accurate as code evolves.

## Changes

- Create `docs/PERSISTENCE_REFERENCE.md` - reference table with file paths and key patterns
- Update `docs/DATABASE.md` - cross-reference to new doc

## Test Plan

- [x] All referenced source files verified to exist
- [x] Cross-links between docs are valid

Closes #195