### PR TITLE
fix(dashboard): resolve POTA data loss and Solar Indices visibility

### DIFF
--- a/src/main/frontend/components/cards/propagation/index.tsx
+++ b/src/main/frontend/components/cards/propagation/index.tsx
@@ -17,18 +17,35 @@ import { formatBandName } from 'Frontend/utils/bandConditions';
 import SolarIndicesContent from './SolarIndicesContent';
 import { BandRatingDisplay } from './BandRatingDisplay';
 
+/** Style for loading state message */
+const loadingStyle: React.CSSProperties = {
+  padding: '1rem',
+  textAlign: 'center',
+  color: 'var(--color-text-secondary)',
+};
+
 /**
  * Solar Indices Card Definition
+ *
+ * Always shows this card, displaying a loading state when data is not yet available.
+ * This ensures users see the card is expected and data is being fetched.
  */
 const solarIndicesCard: CardDefinition = {
-  canRender: (data: DashboardData) => {
-    return !!data.propagation?.solarIndices;
-  },
+  canRender: () => true, // Always show this card
 
   createConfig: (data: DashboardData) => {
-    if (!data.propagation?.solarIndices) return null;
+    const solarIndices = data.propagation?.solarIndices;
 
-    const solarIndices = data.propagation.solarIndices;
+    // When no data, return config with low priority (card still shows with loading state)
+    if (!solarIndices) {
+      return {
+        id: 'solar-indices',
+        type: 'solar-indices',
+        size: 'standard',
+        priority: 0,
+        hotness: 'neutral',
+      };
+    }
 
     // Calculate priority from solar indices
     const priority = calculatePriority({
@@ -57,7 +74,17 @@ const solarIndicesCard: CardDefinition = {
 
   render: (data: DashboardData, config: ActivityCardConfig) => {
     const solarIndices = data.propagation?.solarIndices;
-    if (!solarIndices) return null;
+
+    // Show loading state when data is not yet available
+    if (!solarIndices) {
+      return (
+        <ActivityCard config={config} title="Solar Indices" icon={<Sun size={20} />} subtitle="Loading...">
+          <div className="loading-state" style={loadingStyle}>
+            Fetching solar data...
+          </div>
+        </ActivityCard>
+      );
+    }
 
     return (
       <ActivityCard

--- a/src/main/java/io/nextskip/activations/persistence/entity/ActivationEntity.java
+++ b/src/main/java/io/nextskip/activations/persistence/entity/ActivationEntity.java
@@ -80,7 +80,7 @@ public class ActivationEntity {
     @Column(name = "location_name", nullable = false, length = 200)
     private String locationName;
 
-    @Column(name = "location_region_code", length = 10)
+    @Column(name = "location_region_code", length = 100)
     private String locationRegionCode;
 
     // Park-specific fields (null for SOTA activations)

--- a/src/main/resources/db/changelog/migrations/008-expand-region-code.yaml
+++ b/src/main/resources/db/changelog/migrations/008-expand-region-code.yaml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+  - changeSet:
+      id: expand-location-region-code
+      author: arunderwood
+      comment: Expand location_region_code column to support multi-state POTA activations (e.g., US-CA,US-CO,US-KS,US-MO)
+      changes:
+        - modifyDataType:
+            tableName: activations
+            columnName: location_region_code
+            newDataType: varchar(100)


### PR DESCRIPTION
## Summary
- Expand `location_region_code` column from varchar(10) to varchar(100) to support multi-state POTA activations
- Always show Solar Indices card with loading state when data unavailable
- Update frontend tests for new Solar Indices behavior

## Root Causes Fixed
1. **POTA data loss**: Database column too small for multi-state location values like `US-CA,US-CO,US-KS,US-MO,US-NE,US-NV,US-UT,US-WY`
2. **Solar Indices not appearing**: Card was hidden when data was null instead of showing loading state

## Test Plan
- [x] Java compilation passes
- [x] All 394 frontend tests pass
- [x] ESLint passes
- [x] Prettier formatting passes
- [x] Checkstyle/PMD pass