### PR TITLE
fix(propagation): correct source name strings for solar indices lookup

### DIFF
--- a/src/main/java/io/nextskip/common/config/CacheConfig.java
+++ b/src/main/java/io/nextskip/common/config/CacheConfig.java
@@ -127,8 +127,8 @@ public class CacheConfig {
      * Package-private for testing.
      */
     SolarIndices loadAndMergeSolarIndices(SolarIndicesRepository repository) {
-        Optional<SolarIndicesEntity> noaaOpt = repository.findTopBySourceOrderByTimestampDesc("noaa");
-        Optional<SolarIndicesEntity> hamqslOpt = repository.findTopBySourceOrderByTimestampDesc("hamqsl");
+        Optional<SolarIndicesEntity> noaaOpt = repository.findTopBySourceOrderByTimestampDesc("NOAA SWPC");
+        Optional<SolarIndicesEntity> hamqslOpt = repository.findTopBySourceOrderByTimestampDesc("HamQSL");
 
         SolarIndices noaaData = noaaOpt.map(SolarIndicesEntity::toDomain).orElse(null);
         SolarIndices hamqslData = hamqslOpt.map(SolarIndicesEntity::toDomain).orElse(null);

--- a/src/main/java/io/nextskip/propagation/internal/scheduler/NoaaRefreshTask.java
+++ b/src/main/java/io/nextskip/propagation/internal/scheduler/NoaaRefreshTask.java
@@ -34,7 +34,7 @@ public class NoaaRefreshTask {
     private static final Logger LOG = LoggerFactory.getLogger(NoaaRefreshTask.class);
     private static final String TASK_NAME = "noaa-refresh";
     private static final Duration REFRESH_INTERVAL = Duration.ofMinutes(5);
-    private static final String NOAA_SOURCE = "NOAA";
+    private static final String NOAA_SOURCE = "NOAA SWPC";
 
     /**
      * Creates the recurring task bean for NOAA data refresh.

--- a/src/test/java/io/nextskip/common/config/CacheConfigTest.java
+++ b/src/test/java/io/nextskip/common/config/CacheConfigTest.java
@@ -49,8 +49,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class CacheConfigTest {
 
-    private static final String SOURCE_NOAA = "noaa";
-    private static final String SOURCE_HAMQSL = "hamqsl";
+    private static final String SOURCE_NOAA = "NOAA SWPC";
+    private static final String SOURCE_HAMQSL = "HamQSL";
 
     @Mock
     private ActivationRepository activationRepository;

--- a/src/test/java/io/nextskip/propagation/internal/scheduler/HamQslSolarRefreshTaskTest.java
+++ b/src/test/java/io/nextskip/propagation/internal/scheduler/HamQslSolarRefreshTaskTest.java
@@ -152,7 +152,7 @@ class HamQslSolarRefreshTaskTest {
 
     @Test
     void testNeedsInitialLoad_OnlyNoaaData_ReturnsTrue() {
-        SolarIndicesEntity entity = createTestEntity("NOAA");
+        SolarIndicesEntity entity = createTestEntity("NOAA SWPC");
         when(repository.findByTimestampAfterOrderByTimestampDesc(any(Instant.class)))
                 .thenReturn(List.of(entity));
 

--- a/src/test/java/io/nextskip/propagation/internal/scheduler/NoaaRefreshTaskTest.java
+++ b/src/test/java/io/nextskip/propagation/internal/scheduler/NoaaRefreshTaskTest.java
@@ -130,7 +130,7 @@ class NoaaRefreshTaskTest {
 
     @Test
     void testNeedsInitialLoad_HasNoaaData_ReturnsFalse() {
-        SolarIndicesEntity entity = createTestEntity("NOAA");
+        SolarIndicesEntity entity = createTestEntity("NOAA SWPC");
         when(repository.findByTimestampAfterOrderByTimestampDesc(any(Instant.class)))
                 .thenReturn(List.of(entity));
 


### PR DESCRIPTION
## Summary
- Fix source name mismatch causing "No solar indices data available in database" error
- CacheConfig was querying for lowercase names ("noaa", "hamqsl") but database stores "NOAA SWPC" and "HamQSL"
- Update NoaaRefreshTask NOAA_SOURCE constant for consistent needsInitialLoad() checks

## Root Cause
The previous PR #227 fixed the Solar Indices card visibility (now shows loading state), but the card still showed "Loading..." indefinitely because the database lookup was using wrong source names:

```java
// Before (broken):
repository.findTopBySourceOrderByTimestampDesc("noaa")
repository.findTopBySourceOrderByTimestampDesc("hamqsl")

// After (fixed):
repository.findTopBySourceOrderByTimestampDesc("NOAA SWPC")
repository.findTopBySourceOrderByTimestampDesc("HamQSL")
```

## Verification
Local testing confirmed the fix works:
```
2025-12-30 22:10:26 - Merged solar indices from NOAA and HamQSL
```

## Test plan
- [x] All unit tests pass
- [x] Local verification shows "Merged solar indices from NOAA and HamQSL"
- [ ] Deploy and verify Solar Indices card shows data on nextskip.io