### PR TITLE
test(persistence): add AbstractPersistenceTest base class for test isolation

### DIFF
--- a/src/test/java/io/nextskip/common/scheduler/DbSchedulerIntegrationTest.java
+++ b/src/test/java/io/nextskip/common/scheduler/DbSchedulerIntegrationTest.java
@@ -8,12 +8,10 @@ import io.nextskip.meteors.internal.scheduler.MeteorRefreshTask;
 import io.nextskip.propagation.internal.scheduler.HamQslBandRefreshTask;
 import io.nextskip.propagation.internal.scheduler.HamQslSolarRefreshTask;
 import io.nextskip.propagation.internal.scheduler.NoaaRefreshTask;
-import io.nextskip.test.AbstractIntegrationTest;
+import io.nextskip.test.AbstractSchedulerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,12 +24,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>With the manual DbSchedulerConfig (Spring Boot 4 workaround), the Scheduler bean
  * should now be created successfully in all environments including tests.
  *
- * <p>Uses the scheduler-test profile which enables db-scheduler (most tests use the
- * default test profile which disables scheduler for isolation).
+ * <p>Extends AbstractSchedulerTest which provides scheduled_tasks table cleanup
+ * and uses the scheduler-test profile.
  */
-@SpringBootTest
-@ActiveProfiles("scheduler-test")
-class DbSchedulerIntegrationTest extends AbstractIntegrationTest {
+class DbSchedulerIntegrationTest extends AbstractSchedulerTest {
 
     @Autowired
     private ApplicationContext applicationContext;

--- a/src/test/java/io/nextskip/propagation/persistence/BandConditionEntityIntegrationTest.java
+++ b/src/test/java/io/nextskip/propagation/persistence/BandConditionEntityIntegrationTest.java
@@ -5,15 +5,16 @@ import io.nextskip.propagation.model.BandCondition;
 import io.nextskip.propagation.model.BandConditionRating;
 import io.nextskip.propagation.persistence.entity.BandConditionEntity;
 import io.nextskip.propagation.persistence.repository.BandConditionRepository;
-import io.nextskip.test.AbstractIntegrationTest;
+import io.nextskip.test.AbstractPersistenceTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -33,12 +34,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *   <li>Constraint enforcement</li>
  * </ul>
  */
-@SpringBootTest
-@Transactional
-class BandConditionEntityIntegrationTest extends AbstractIntegrationTest {
+class BandConditionEntityIntegrationTest extends AbstractPersistenceTest {
 
     @Autowired
     private BandConditionRepository repository;
+
+    @Override
+    protected Collection<JpaRepository<?, ?>> getRepositoriesToClean() {
+        return List.of(repository);
+    }
 
     @Test
     void testFromDomain_PreservesAllFields() {
@@ -174,7 +178,6 @@ class BandConditionEntityIntegrationTest extends AbstractIntegrationTest {
     @Test
     void testFindByBandAndRecordedAtAfterOrderByRecordedAtDesc_ReturnsRecentForBand() {
         // Given: Multiple entries for same band at different times
-        // Use BAND_6M which is not used by any other test to avoid test isolation issues
         var now = Instant.now();
         var twoHoursAgo = now.minus(2, ChronoUnit.HOURS);
         var oneHourAgo = now.minus(1, ChronoUnit.HOURS);

--- a/src/test/java/io/nextskip/propagation/persistence/SolarIndicesEntityIntegrationTest.java
+++ b/src/test/java/io/nextskip/propagation/persistence/SolarIndicesEntityIntegrationTest.java
@@ -3,16 +3,16 @@ package io.nextskip.propagation.persistence;
 import io.nextskip.propagation.model.SolarIndices;
 import io.nextskip.propagation.persistence.entity.SolarIndicesEntity;
 import io.nextskip.propagation.persistence.repository.SolarIndicesRepository;
-import io.nextskip.test.AbstractIntegrationTest;
-import org.junit.jupiter.api.BeforeEach;
+import io.nextskip.test.AbstractPersistenceTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -30,21 +30,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *   <li>Constraint enforcement</li>
  * </ul>
  */
-@SpringBootTest
-@Transactional
-class SolarIndicesEntityIntegrationTest extends AbstractIntegrationTest {
+class SolarIndicesEntityIntegrationTest extends AbstractPersistenceTest {
 
-    // Use unique test source names to avoid conflicts with scheduler data
-    private static final String SOURCE_NOAA = "TEST_NOAA";
-    private static final String SOURCE_HAMQSL = "TEST_HAMQSL";
+    private static final String SOURCE_NOAA = "NOAA";
+    private static final String SOURCE_HAMQSL = "HAMQSL";
 
     @Autowired
     private SolarIndicesRepository repository;
 
-    @BeforeEach
-    void cleanUp() {
-        // Clean slate for tests using unfiltered queries (e.g., findByTimestampAfter)
-        repository.deleteAll();
+    @Override
+    protected Collection<JpaRepository<?, ?>> getRepositoriesToClean() {
+        return List.of(repository);
     }
 
     @Test

--- a/src/test/java/io/nextskip/test/AbstractPersistenceTest.java
+++ b/src/test/java/io/nextskip/test/AbstractPersistenceTest.java
@@ -1,0 +1,92 @@
+package io.nextskip.test;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Base class for persistence integration tests.
+ *
+ * <p>Provides consistent test isolation through:
+ * <ul>
+ *   <li>{@code @BeforeEach} cleanup of all repositories returned by {@link #getRepositoriesToClean()}</li>
+ *   <li>EntityManager cache clearing for accurate state verification</li>
+ * </ul>
+ *
+ * <p>Why this is needed:
+ * <ul>
+ *   <li>{@code @Transactional} rollback alone fails with {@code saveAndFlush()}</li>
+ *   <li>Singleton TestContainers means data can persist between test classes</li>
+ *   <li>EntityManager cache can mask actual database state</li>
+ * </ul>
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * @SpringBootTest
+ * @Transactional
+ * class MyEntityIntegrationTest extends AbstractPersistenceTest {
+ *
+ *     @Autowired
+ *     private MyRepository repository;
+ *
+ *     @Override
+ *     protected Collection<JpaRepository<?, ?>> getRepositoriesToClean() {
+ *         return List.of(repository);
+ *     }
+ *
+ *     @Test
+ *     void testSomething() {
+ *         // Repository is cleaned before this runs
+ *     }
+ * }
+ * }</pre>
+ */
+@SpringBootTest
+@Transactional
+public abstract class AbstractPersistenceTest extends AbstractIntegrationTest {
+
+    @Autowired
+    protected EntityManager entityManager;
+
+    /**
+     * Returns the repositories that should be cleaned before each test.
+     *
+     * <p>Override this method to specify which repositories need cleanup.
+     * Repositories are cleaned in iteration order, so for foreign key constraints,
+     * return dependent tables first (child before parent).
+     *
+     * @return collection of repositories to clean, or empty if no cleanup needed
+     */
+    protected Collection<JpaRepository<?, ?>> getRepositoriesToClean() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Cleans all repositories before each test.
+     *
+     * <p>Calls {@link #getRepositoriesToClean()} and deletes all data from each repository,
+     * then clears the persistence context to ensure fresh reads.
+     */
+    @BeforeEach
+    void cleanupBeforeTest() {
+        getRepositoriesToClean().forEach(JpaRepository::deleteAll);
+        clearPersistenceContext();
+    }
+
+    /**
+     * Clears the persistence context to ensure fresh reads from database.
+     *
+     * <p>Call this after {@code saveAndFlush()} operations when you need
+     * to verify the actual database state rather than cached entities.
+     */
+    protected void clearPersistenceContext() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/test/java/io/nextskip/test/AbstractSchedulerTest.java
+++ b/src/test/java/io/nextskip/test/AbstractSchedulerTest.java
@@ -1,0 +1,53 @@
+package io.nextskip.test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Base class for scheduler integration tests.
+ *
+ * <p>Uses the scheduler-test profile which enables db-scheduler
+ * with a long polling interval (1 hour) to prevent actual task execution
+ * during tests.
+ *
+ * <p>Provides cleanup of the scheduled_tasks table between tests to ensure
+ * isolation when testing scheduler state or task persistence.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * class MySchedulerTest extends AbstractSchedulerTest {
+ *
+ *     @Autowired
+ *     private Scheduler scheduler;
+ *
+ *     @Test
+ *     void testSchedulerBehavior() {
+ *         // scheduled_tasks table is cleaned before this runs
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>Note: Most tests should use the default test profile (scheduler disabled).
+ * Only extend this class when specifically testing scheduler functionality.
+ */
+@SpringBootTest
+@ActiveProfiles("scheduler-test")
+public abstract class AbstractSchedulerTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    /**
+     * Cleans the scheduled_tasks table before each test.
+     *
+     * <p>This ensures test isolation when verifying scheduler state,
+     * task execution history, or task registration.
+     */
+    @BeforeEach
+    void cleanScheduledTasks() {
+        jdbcTemplate.execute("DELETE FROM scheduled_tasks");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AbstractPersistenceTest` base class with `@BeforeEach` cleanup via `getRepositoriesToClean()` override pattern
- Add `AbstractSchedulerTest` base class for scheduler-specific tests with `scheduled_tasks` table cleanup
- Migrate all 6 persistence/scheduler integration tests to use new base classes
- Remove TEST_ prefix workarounds (no longer needed with proper cleanup)

## Why
Resolves test isolation issues caused by:
- `@Transactional` rollback failing with `saveAndFlush()` calls
- Singleton TestContainers persisting data between test classes
- EntityManager cache masking actual database state

## Test plan
- [x] All backend tests pass (`./gradlew test`)
- [x] Full build passes with quality checks (`./gradlew build`)
- [x] Frontend validation passes (`npm run validate`)
- [x] E2E tests pass (`npm run e2e`)
- [x] Application starts without runtime exceptions