### PR TITLE
test(common): add Clock injection for deterministic time-based tests

### DIFF
--- a/src/main/java/io/nextskip/activations/internal/ActivationsServiceImpl.java
+++ b/src/main/java/io/nextskip/activations/internal/ActivationsServiceImpl.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 
@@ -28,10 +29,12 @@ public class ActivationsServiceImpl implements ActivationsService {
     private static final Logger LOG = LoggerFactory.getLogger(ActivationsServiceImpl.class);
 
     private final LoadingCache<String, List<Activation>> activationsCache;
+    private final Clock clock;
 
     @Autowired
-    public ActivationsServiceImpl(LoadingCache<String, List<Activation>> activationsCache) {
+    public ActivationsServiceImpl(LoadingCache<String, List<Activation>> activationsCache, Clock clock) {
         this.activationsCache = activationsCache;
+        this.clock = clock;
     }
 
     @Override
@@ -58,7 +61,7 @@ public class ActivationsServiceImpl implements ActivationsService {
                 allActivations,
                 potaCount,
                 sotaCount,
-                Instant.now()
+                Instant.now(clock)
         );
     }
 

--- a/src/main/java/io/nextskip/common/config/ClockConfig.java
+++ b/src/main/java/io/nextskip/common/config/ClockConfig.java
@@ -1,0 +1,42 @@
+package io.nextskip.common.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+/**
+ * Configuration for time-based operations.
+ *
+ * <p>Provides a default system clock that can be overridden in tests
+ * for deterministic time-based assertions.
+ *
+ * <p>Usage in tests:
+ * <pre>{@code
+ * private static final Instant FIXED_TIME = Instant.parse("2025-01-15T12:00:00Z");
+ * private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_TIME, ZoneOffset.UTC);
+ *
+ * @BeforeEach
+ * void setUp() {
+ *     service = new SomeService(dependency, FIXED_CLOCK);
+ * }
+ * }</pre>
+ */
+@Configuration
+public class ClockConfig {
+
+    /**
+     * Provides a default system clock using UTC timezone.
+     *
+     * <p>This bean can be overridden in tests by defining a {@code Clock.fixed()}
+     * bean, which will take precedence due to {@code @ConditionalOnMissingBean}.
+     *
+     * @return the system clock in UTC
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/src/main/java/io/nextskip/contests/internal/ContestServiceImpl.java
+++ b/src/main/java/io/nextskip/contests/internal/ContestServiceImpl.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -28,10 +29,12 @@ public class ContestServiceImpl implements ContestService {
     private static final Logger LOG = LoggerFactory.getLogger(ContestServiceImpl.class);
 
     private final LoadingCache<String, List<Contest>> contestsCache;
+    private final Clock clock;
 
     @Autowired
-    public ContestServiceImpl(LoadingCache<String, List<Contest>> contestsCache) {
+    public ContestServiceImpl(LoadingCache<String, List<Contest>> contestsCache, Clock clock) {
         this.contestsCache = contestsCache;
+        this.clock = clock;
     }
 
     @Override
@@ -70,7 +73,7 @@ public class ContestServiceImpl implements ContestService {
                 activeCount,
                 upcomingCount,
                 totalCount,
-                Instant.now()
+                Instant.now(clock)
         );
 
         LOG.debug("Returning contests response: {} active, {} upcoming soon, {} total",

--- a/src/main/java/io/nextskip/propagation/internal/PropagationServiceImpl.java
+++ b/src/main/java/io/nextskip/propagation/internal/PropagationServiceImpl.java
@@ -12,6 +12,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -32,12 +34,15 @@ public class PropagationServiceImpl implements PropagationService {
 
     private final LoadingCache<String, SolarIndices> solarIndicesCache;
     private final LoadingCache<String, List<BandCondition>> bandConditionsCache;
+    private final Clock clock;
 
     public PropagationServiceImpl(
             LoadingCache<String, SolarIndices> solarIndicesCache,
-            LoadingCache<String, List<BandCondition>> bandConditionsCache) {
+            LoadingCache<String, List<BandCondition>> bandConditionsCache,
+            Clock clock) {
         this.solarIndicesCache = solarIndicesCache;
         this.bandConditionsCache = bandConditionsCache;
+        this.clock = clock;
     }
 
     /**
@@ -102,7 +107,7 @@ public class PropagationServiceImpl implements PropagationService {
         SolarIndices solarIndices = getCurrentSolarIndices();
         List<BandCondition> bandConditions = getBandConditions();
 
-        PropagationResponse response = new PropagationResponse(solarIndices, bandConditions);
+        PropagationResponse response = new PropagationResponse(solarIndices, bandConditions, Instant.now(clock));
 
         LOG.debug("Returning propagation response: {} band conditions",
                 bandConditions.size());

--- a/src/test/java/io/nextskip/common/config/CacheConfigTest.java
+++ b/src/test/java/io/nextskip/common/config/CacheConfigTest.java
@@ -26,7 +26,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -51,6 +53,8 @@ class CacheConfigTest {
 
     private static final String SOURCE_NOAA = "NOAA SWPC";
     private static final String SOURCE_HAMQSL = "HamQSL";
+    private static final Instant FIXED_TIME = Instant.parse("2025-01-15T12:00:00Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_TIME, ZoneOffset.UTC);
 
     @Mock
     private ActivationRepository activationRepository;
@@ -71,7 +75,7 @@ class CacheConfigTest {
 
     @BeforeEach
     void setUp() {
-        config = new CacheConfig();
+        config = new CacheConfig(FIXED_CLOCK);
     }
 
     @Test

--- a/src/test/java/io/nextskip/propagation/internal/PropagationServiceImplTest.java
+++ b/src/test/java/io/nextskip/propagation/internal/PropagationServiceImplTest.java
@@ -13,7 +13,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.test.StepVerifier;
 
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,6 +35,8 @@ import static org.mockito.Mockito.when;
 class PropagationServiceImplTest {
 
     private static final String MERGED_SOURCE = "NOAA SWPC + HamQSL";
+    private static final Instant FIXED_TIME = Instant.parse("2025-01-15T12:00:00Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_TIME, ZoneOffset.UTC);
 
     @Mock
     private LoadingCache<String, SolarIndices> solarIndicesCache;
@@ -47,7 +51,7 @@ class PropagationServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        service = new PropagationServiceImpl(solarIndicesCache, bandConditionsCache);
+        service = new PropagationServiceImpl(solarIndicesCache, bandConditionsCache, FIXED_CLOCK);
 
         // Setup test data - merged solar indices (as would be produced by cache loader)
         mergedSolarIndices = new SolarIndices(
@@ -55,7 +59,7 @@ class PropagationServiceImplTest {
                 8,      // A-index from HamQSL
                 3,      // K-index from HamQSL
                 120,    // Sunspots from NOAA
-                Instant.now(),
+                FIXED_TIME,
                 MERGED_SOURCE
         );
 


### PR DESCRIPTION
## Summary

- Add `ClockConfig` providing default `Clock.systemUTC()` bean with `@ConditionalOnMissingBean` for test overrides
- Inject `Clock` into services (`ActivationsServiceImpl`, `ContestServiceImpl`, `PropagationServiceImpl`) and `CacheConfig`
- Replace `Instant.now()` with `Instant.now(clock)` for deterministic timestamps
- Update tests to use `Clock.fixed()` for exact timestamp assertions

## Motivation

Current tests use flaky window-based assertions that fail intermittently on slow CI runners:

```java
Instant before = Instant.now();
// ... service call ...
Instant after = Instant.now();
assertTrue(result.isAfter(before));  // Flaky!
```

With Clock injection, tests are deterministic:

```java
private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_TIME, ZoneOffset.UTC);
assertEquals(FIXED_TIME, summary.lastUpdated());  // Deterministic!
```

## Test plan

- [x] All tests pass (`./gradlew test`)
- [x] Quality gates pass (`./gradlew check`)

Closes #244