### PR TITLE
refactor(frontend): rename card sizes to grid-based format

### DIFF
--- a/src/main/frontend/components/activity/ActivityCard.css
+++ b/src/main/frontend/components/activity/ActivityCard.css
@@ -290,15 +290,15 @@
 }
 
 /* Size-specific adjustments */
-.activity-card--tall .activity-card__content {
+.activity-card--1x2 .activity-card__content {
   padding: calc(var(--spacing-unit) * 2.5);
 }
 
-.activity-card--hero .activity-card__header {
+.activity-card--2x2 .activity-card__header {
   padding: calc(var(--spacing-unit) * 2.5);
 }
 
-.activity-card--hero .activity-card__title {
+.activity-card--2x2 .activity-card__title {
   font-size: 1.375rem;
 }
 
@@ -318,7 +318,7 @@
     font-size: 1rem;
   }
 
-  .activity-card--hero .activity-card__title {
+  .activity-card--2x2 .activity-card__title {
     font-size: 1.125rem;
   }
 }

--- a/src/main/frontend/components/activity/ActivityGrid.tsx
+++ b/src/main/frontend/components/activity/ActivityGrid.tsx
@@ -12,10 +12,10 @@ import './ActivityGrid.css';
 
 // Map card size to Frame aspect ratio
 const SIZE_TO_ASPECT: Record<ActivityCardSize, { width: number; height: number }> = {
-  standard: { width: 1, height: 1 },
-  wide: { width: 2, height: 1 },
-  tall: { width: 1, height: 2 },
-  hero: { width: 2, height: 2 },
+  '1x1': { width: 1, height: 1 },
+  '2x1': { width: 2, height: 1 },
+  '1x2': { width: 1, height: 2 },
+  '2x2': { width: 2, height: 2 },
 };
 
 // Style override to prevent glow clipping at grid edges

--- a/src/main/frontend/components/cards/activations/index.tsx
+++ b/src/main/frontend/components/cards/activations/index.tsx
@@ -49,7 +49,7 @@ const potaActivationsCard: CardDefinition = {
     return {
       id: 'pota-activations',
       type: 'pota-activations',
-      size: 'tall',
+      size: '1x2',
       priority,
       hotness,
     };
@@ -115,7 +115,7 @@ const sotaActivationsCard: CardDefinition = {
     return {
       id: 'sota-activations',
       type: 'sota-activations',
-      size: 'tall',
+      size: '1x2',
       priority,
       hotness,
     };

--- a/src/main/frontend/components/cards/contests/index.tsx
+++ b/src/main/frontend/components/cards/contests/index.tsx
@@ -54,7 +54,7 @@ const contestsCard: CardDefinition = {
       return {
         id: uniqueId,
         type: 'contests',
-        size: 'standard' as const,
+        size: '1x1' as const,
         priority,
         hotness: priorityToHotness(priority),
       };

--- a/src/main/frontend/components/cards/meteor-showers/index.tsx
+++ b/src/main/frontend/components/cards/meteor-showers/index.tsx
@@ -175,7 +175,7 @@ const meteorShowersCard: CardDefinition = {
       return {
         id: uniqueId,
         type: 'event-meteor-shower',
-        size: 'standard' as const,
+        size: '1x1' as const,
         priority,
         hotness: priorityToHotness(priority),
       };

--- a/src/main/frontend/components/cards/propagation/index.tsx
+++ b/src/main/frontend/components/cards/propagation/index.tsx
@@ -41,7 +41,7 @@ const solarIndicesCard: CardDefinition = {
       return {
         id: 'solar-indices',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 0,
         hotness: 'neutral',
       };
@@ -66,7 +66,7 @@ const solarIndicesCard: CardDefinition = {
     return {
       id: 'solar-indices',
       type: 'solar-indices',
-      size: 'standard',
+      size: '1x1',
       priority,
       hotness,
     };
@@ -146,7 +146,7 @@ const bandConditionCards: CardDefinition = {
         return {
           id: `band-${condition.band}`,
           type: 'band-condition',
-          size: 'standard' as const,
+          size: '1x1' as const,
           priority: score,
           hotness: priorityToHotness(score),
         };

--- a/src/main/frontend/docs/COMPONENT_PATTERNS.md
+++ b/src/main/frontend/docs/COMPONENT_PATTERNS.md
@@ -471,7 +471,7 @@ const { priority, hotness } = usePriorityCalculation({
 const config: ActivityCardConfig = {
   id: 'unique-id',
   type: 'activity-type',
-  size: 'standard', // or 'wide', 'tall', 'hero'
+  size: '1x1', // or '2x1', '1x2', '2x2'
   priority,
   hotness,
 };
@@ -490,12 +490,12 @@ const config: ActivityCardConfig = {
 
 ### Card Size Selection Guide
 
-Choose card size based on content needs:
+Choose card size based on content needs. Sizes use "{columns}x{rows}" format:
 
-- **standard (1x1)**: Simple metrics (single number, status indicator)
-- **wide (2x1)**: Tables, charts, horizontal lists
-- **tall (1x2)**: Vertical lists, activity feeds
-- **hero (2x2)**: Rich dashboards, featured metrics with charts
+- **1x1** (single cell): Simple metrics (single number, status indicator)
+- **2x1** (wide): Tables, charts, horizontal lists
+- **1x2** (tall): Vertical lists, activity feeds
+- **2x2** (hero): Rich dashboards, featured metrics with charts
 
 ### Content Component Pattern
 
@@ -546,7 +546,7 @@ export function useDashboardCards(data: DashboardData | null): ActivityCardConfi
     return {
       id: 'activity',
       type: 'activity-type',
-      size: 'standard',
+      size: '1x1',
       priority,
       hotness,
     };

--- a/src/main/frontend/docs/DESIGN_SYSTEM.md
+++ b/src/main/frontend/docs/DESIGN_SYSTEM.md
@@ -233,14 +233,14 @@ Responsive column counts are handled by `useResponsiveFrameWidth()` hook:
 
 ### Card Sizes
 
-Cards use Frame aspect ratios (handled by `@masonry-grid/react`):
+Cards use Frame aspect ratios (handled by `@masonry-grid/react`). Sizes use "{columns}x{rows}" format:
 
-| Size               | Aspect Ratio        | Use Case                       |
-| ------------------ | ------------------- | ------------------------------ |
-| **standard** (1x1) | width: 1, height: 1 | Single metrics, utilities      |
-| **wide** (2x1)     | width: 2, height: 1 | Charts, tables                 |
-| **tall** (1x2)     | width: 1, height: 2 | Lists, activity feeds          |
-| **hero** (2x2)     | width: 2, height: 2 | Primary KPIs, featured metrics |
+| Size    | Aspect Ratio        | Use Case                       |
+| ------- | ------------------- | ------------------------------ |
+| **1x1** | width: 1, height: 1 | Single metrics, utilities      |
+| **2x1** | width: 2, height: 1 | Charts, tables                 |
+| **1x2** | width: 1, height: 2 | Lists, activity feeds          |
+| **2x2** | width: 2, height: 2 | Primary KPIs, featured metrics |
 
 ### Hotness Levels
 
@@ -296,7 +296,7 @@ import { ActivityGrid, ActivityCard } from '../components/activity';
 <ActivityGrid
   cards={[
     {
-      config: { id: 'solar', type: 'solar-indices', size: 'standard', priority: 85, hotness: 'hot' },
+      config: { id: 'solar', type: 'solar-indices', size: '1x1', priority: 85, hotness: 'hot' },
       component: (
         <ActivityCard config={config} title="Solar Indices" icon="☀️">
           <SolarIndicesContent data={solarData} />

--- a/src/main/frontend/types/activity.ts
+++ b/src/main/frontend/types/activity.ts
@@ -8,13 +8,14 @@
 import type { ReactNode } from 'react';
 
 /**
- * Card size variants for activity grid layout
- * - standard: 1x1 (single cell) - Single metrics, utilities
- * - wide: 2x1 (spans 2 columns) - Charts, tables
- * - tall: 1x2 (spans 2 rows) - Lists, activity feeds
- * - hero: 2x2 (spans 2 columns and 2 rows) - Primary KPIs, featured metrics
+ * Card size variants for activity grid layout.
+ * Format: "{columns}x{rows}" representing grid cell spans.
+ * - '1x1': Single cell (1 column, 1 row) - Single metrics, utilities
+ * - '2x1': Wide (2 columns, 1 row) - Charts, tables
+ * - '1x2': Tall (1 column, 2 rows) - Lists, activity feeds
+ * - '2x2': Hero (2 columns, 2 rows) - Primary KPIs, featured metrics
  */
-export type ActivityCardSize = 'standard' | 'wide' | 'tall' | 'hero';
+export type ActivityCardSize = '1x1' | '2x1' | '1x2' | '2x2';
 
 /**
  * Hotness level determines visual emphasis and border glow intensity

--- a/src/test/frontend/components/activity/ActivityCard.test.tsx
+++ b/src/test/frontend/components/activity/ActivityCard.test.tsx
@@ -16,7 +16,7 @@ expect.extend(toHaveNoViolations);
 const mockConfig: ActivityCardConfig = {
   id: 'test-card',
   type: 'solar-indices',
-  size: 'standard',
+  size: '1x1',
   priority: 75,
   hotness: 'hot',
 };
@@ -78,10 +78,10 @@ describe('ActivityCard', () => {
 
   describe('card sizes', () => {
     it.each([
-      ['standard', 'activity-card--standard'],
-      ['wide', 'activity-card--wide'],
-      ['tall', 'activity-card--tall'],
-      ['hero', 'activity-card--hero'],
+      ['1x1', 'activity-card--1x1'],
+      ['2x1', 'activity-card--2x1'],
+      ['1x2', 'activity-card--1x2'],
+      ['2x2', 'activity-card--2x2'],
     ] as const)('should apply %s size class', (size, expectedClass) => {
       const config = { ...mockConfig, size };
       const { container } = render(

--- a/src/test/frontend/components/activity/ActivityGrid.test.tsx
+++ b/src/test/frontend/components/activity/ActivityGrid.test.tsx
@@ -18,7 +18,7 @@ const createCard = (
   id: string,
   priority: number,
   hotness: 'hot' | 'warm' | 'neutral' | 'cool',
-  size: 'standard' | 'wide' | 'tall' | 'hero' = 'standard',
+  size: '1x1' | '2x1' | '1x2' | '2x2' = '1x1',
 ): ActivityCardConfig => ({
   id,
   type: 'solar-indices',

--- a/src/test/frontend/components/activity/ActivitySystem.a11y.test.tsx
+++ b/src/test/frontend/components/activity/ActivitySystem.a11y.test.tsx
@@ -19,7 +19,7 @@ const createTestCard = (id: string, priority: number, title: string, interactive
   const config: ActivityCardConfig = {
     id,
     type: 'solar-indices',
-    size: 'standard',
+    size: '1x1',
     priority,
     hotness: priority >= 70 ? 'hot' : priority >= 45 ? 'warm' : 'neutral',
   };
@@ -147,7 +147,7 @@ describe('Activity System Accessibility', () => {
       const config: ActivityCardConfig = {
         id: 'test',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 75,
         hotness: 'hot',
       };
@@ -174,7 +174,7 @@ describe('Activity System Accessibility', () => {
       const config: ActivityCardConfig = {
         id: 'test',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 75,
         hotness: 'hot',
       };
@@ -233,28 +233,28 @@ describe('Activity System Accessibility', () => {
       const config1: ActivityCardConfig = {
         id: 'hot',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 85,
         hotness: 'hot',
       };
       const config2: ActivityCardConfig = {
         id: 'warm',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 55,
         hotness: 'warm',
       };
       const config3: ActivityCardConfig = {
         id: 'neutral',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 35,
         hotness: 'neutral',
       };
       const config4: ActivityCardConfig = {
         id: 'cool',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 15,
         hotness: 'cool',
       };
@@ -387,7 +387,7 @@ describe('Activity System Accessibility', () => {
       const config: ActivityCardConfig = {
         id: 'test',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 75,
         hotness: 'hot',
       };
@@ -408,28 +408,28 @@ describe('Activity System Accessibility', () => {
       const config1: ActivityCardConfig = {
         id: 'hot',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 85,
         hotness: 'hot',
       };
       const config2: ActivityCardConfig = {
         id: 'warm',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 55,
         hotness: 'warm',
       };
       const config3: ActivityCardConfig = {
         id: 'neutral',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 35,
         hotness: 'neutral',
       };
       const config4: ActivityCardConfig = {
         id: 'cool',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 15,
         hotness: 'cool',
       };

--- a/src/test/frontend/components/cards/CardRegistry.test.ts
+++ b/src/test/frontend/components/cards/CardRegistry.test.ts
@@ -21,7 +21,7 @@ describe('CardRegistry', () => {
       createConfig: () => ({
         id: 'test-card',
         type: 'propagation',
-        size: 'standard',
+        size: '1x1',
         priority: 50,
         hotness: 'neutral',
       }),
@@ -41,7 +41,7 @@ describe('CardRegistry', () => {
       createConfig: () => ({
         id: 'card-1',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
         priority: 100,
         hotness: 'hot',
       }),
@@ -53,7 +53,7 @@ describe('CardRegistry', () => {
       createConfig: () => ({
         id: 'card-2',
         type: 'band-conditions',
-        size: 'wide',
+        size: '2x1',
         priority: 50,
         hotness: 'warm',
       }),

--- a/src/test/frontend/hooks/useDashboardCards.test.ts
+++ b/src/test/frontend/hooks/useDashboardCards.test.ts
@@ -278,7 +278,7 @@ describe('useDashboardCards', () => {
       };
       const { result } = renderHook(() => useDashboardCards(dashboardData));
 
-      expect(result.current[0].size).toBe('standard');
+      expect(result.current[0].size).toBe('1x1');
     });
   });
 
@@ -311,7 +311,7 @@ describe('useDashboardCards', () => {
       expect(result.current[0]).toMatchObject({
         id: 'solar-indices',
         type: 'solar-indices',
-        size: 'standard',
+        size: '1x1',
       });
     });
 
@@ -390,7 +390,7 @@ describe('useDashboardCards', () => {
       expect(bandCard).toMatchObject({
         id: 'band-BAND_20M',
         type: 'band-condition',
-        size: 'standard',
+        size: '1x1',
       });
     });
 


### PR DESCRIPTION
## Summary

- Renames activity card sizes from semantic names (`standard`, `wide`, `tall`, `hero`) to explicit grid-based names (`1x1`, `2x1`, `1x2`, `2x2`)
- Makes the sizing system self-documenting - the name tells you exactly how many columns and rows the card spans
- Updates CSS classes, TypeScript types, card components, tests, and documentation

| Old | New | Meaning |
|-----|-----|---------|
| `standard` | `1x1` | 1 column, 1 row |
| `wide` | `2x1` | 2 columns, 1 row |
| `tall` | `1x2` | 1 column, 2 rows |
| `hero` | `2x2` | 2 columns, 2 rows |

## Test plan

- [x] All 394 frontend tests pass (`npm run test:run`)
- [x] Full Gradle build succeeds (`./gradlew build`)
- [ ] Visual verification of card layout in dashboard

Closes #155