### PR TITLE
feat(quality): add frontend delta coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -131,6 +133,15 @@ jobs:
 
       - name: Run frontend CI test suites (format, lint, tests, coverage)
         run: npm run test:ci
+
+      - name: Check delta coverage on changed files
+        run: |
+          DIFF=$(git diff origin/main -- 'src/main/frontend/**' 'src/test/frontend/**')
+          if [ -z "$DIFF" ]; then
+            echo "No frontend changes to check"
+          else
+            echo "$DIFF" | npx cover-diff
+          fi
 
       - name: Upload ESLint SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ open build/reports/checkstyle/main.html
 open build/reports/pmd/main.html
 ```
 
-**Coverage Requirements**: 75% instruction, 65% branch (enforced by JaCoCo)
+**Coverage Requirements**: 75% instruction, 65% branch (overall); 80% on changed code (delta coverage)
 
 **Fix violations, don't suppress them.** Rule exclusions lower the quality bar. Suppressions require documented justification (e.g., `@SuppressWarnings("PMD.TooManyMethods") // Comprehensive test suite`).
 
@@ -181,9 +181,20 @@ npm run format
 #### Pre-Commit Validation
 
 ```bash
-npm run validate       # Quick: format, lint, unit tests (~3s)
-npm run validate:full  # Full: includes E2E tests (~20s)
+npm run validate       # format, lint, delta coverage
+npm run validate:quick # format, lint, unit tests (no delta coverage)
+npm run validate:full  # includes E2E tests
 ```
+
+#### Delta Coverage
+
+Enforces 80% line / 70% branch coverage on changed files:
+
+```bash
+npm run test:delta     # Run tests + check delta coverage
+```
+
+Uses `@atakama/cover-diff` to compare coverage against `origin/main`.
 
 ## Architecture Guidelines
 

--- a/build.gradle
+++ b/build.gradle
@@ -272,17 +272,11 @@ jacocoTestCoverageVerification {
 }
 
 // Delta coverage: enforce coverage on changed code (PR patch coverage)
-// Matches codecov.yml patch target of 65%
 deltaCoverageReport {
-    // Compare against main branch to measure coverage on changed code
     diffSource.git.compareWith 'refs/remotes/origin/main'
 
-    // Coverage thresholds matching codecov.yml patch target (65%)
     reportViews.test.violationRules {
-        // Simple threshold - applies to all coverage entities (instruction, branch, line)
-        failIfCoverageLessThan(0.65d)
-
-        // Fail the build on violations
+        failIfCoverageLessThan(0.80d)
         failOnViolation.set(true)
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "schema-dts": "^1.1.5"
       },
       "devDependencies": {
+        "@atakama/cover-diff": "^1.2.3",
         "@babel/preset-react": "^7.28.5",
         "@microsoft/eslint-formatter-sarif": "^3.1.0",
         "@playwright/test": "^1.57.0",
@@ -225,6 +226,78 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@atakama/cover-diff": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@atakama/cover-diff/-/cover-diff-1.2.3.tgz",
+      "integrity": "sha512-oSDAqwW7clhB5qc2PR5G/Uf/tRiac6+CDrbXWicftv9Md6itGwIPqZdcKPWMu7yh2IAQn2BovwFNh6H0+cZSzw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "get-stdin": "^8.0.0",
+        "lcov-parse": "^1.0.0",
+        "parse-diff": "^0.7.0"
+      },
+      "bin": {
+        "cover-diff": "cli.js"
+      }
+    },
+    "node_modules/@atakama/cover-diff/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@atakama/cover-diff/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@atakama/cover-diff/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@atakama/cover-diff/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -9928,6 +10001,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -11622,6 +11708,16 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/lcov-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "integrity": "sha512-aprLII/vPzuQvYZnDRU78Fns9I2Ag3gi4Ipga/hxnVMCZC8DnR2nI7XBqrPoywGfxqIx/DgarGvDJZAD3YBTgQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "lcov-parse": "bin/cli.js"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -12390,6 +12486,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -12409,6 +12515,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-diff": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/parse-diff/-/parse-diff-0.7.1.tgz",
+      "integrity": "sha512-1j3l8IKcy4yRK2W4o9EYvJLSzpAVwz4DXqCewYyx2vEwk2gcf3DBPqc8Fj4XV3K33OYJ08A8fWwyu/ykD/HUSg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:ci": "npm run format:check && npm run lint && npm run lint:sarif && vitest run --coverage --reporter=default --reporter=github-actions",
+    "test:delta": "npm run test:coverage && DIFF=$(git diff origin/main -- 'src/main/frontend/**' 'src/test/frontend/**'); if [ -z \"$DIFF\" ]; then echo 'No frontend changes to check'; else echo \"$DIFF\" | npx cover-diff; fi",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:headed": "playwright test --headed",
@@ -17,7 +18,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,json,css,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,json,css,md}\"",
     "typecheck": "tsc --noEmit",
-    "validate": "npm run format:check && npm run lint && npm run test:run",
+    "validate": "npm run format:check && npm run lint && npm run test:delta",
+    "validate:quick": "npm run format:check && npm run lint && npm run test:run",
     "validate:full": "npm run validate && npm run e2e",
     "generate-pwa-icons": "pwa-asset-generator src/main/resources/static/favicon.svg src/main/resources/META-INF/resources/icons --icon-only --favicon --background '#0d1117' --type png --padding 0"
   },
@@ -53,6 +55,7 @@
     "schema-dts": "^1.1.5"
   },
   "devDependencies": {
+    "@atakama/cover-diff": "^1.2.3",
     "@babel/preset-react": "^7.28.5",
     "@microsoft/eslint-formatter-sarif": "^3.1.0",
     "@playwright/test": "^1.57.0",
@@ -244,5 +247,9 @@
       "workbox-build": "7.4.0"
     },
     "hash": "80690df6ee27b029d1b7f3f11e610951704adf8f3e9011261309f1706986c03c"
+  },
+  "@atakama/cover-diff": {
+    "lines": 80,
+    "branches": 70
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     css: true,
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
+      reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],
       exclude: [
         'node_modules/',
         'src/test/',


### PR DESCRIPTION
## Summary

Add local-first delta coverage for frontend tests using `@atakama/cover-diff`, mirroring the backend's `deltaCoverage` Gradle task. Bump both frontend and backend delta thresholds to 80% based on industry standards.

### Changes

- Add `@atakama/cover-diff` (9 packages, 0 vulnerabilities) for frontend delta coverage
- Add `test:delta` script enforcing 80% line / 70% branch on changed files
- Update `validate` to include delta coverage; add `validate:quick` escape hatch
- Add delta coverage step to CI workflow after `test:ci`
- Bump backend delta threshold from 65% to 80%

### New Scripts

```bash
npm run validate       # format, lint, delta coverage
npm run validate:quick # format, lint, tests (no delta check)
npm run test:delta     # tests + delta coverage enforcement
```

## Test Plan

- [x] `npm run test:delta` works locally
- [x] Empty diff gracefully passes ("No frontend changes to check")
- [x] Correct thresholds applied (80% line / 70% branch)
- [ ] CI workflow runs delta coverage step