### PR TITLE
test: consolidate mock factories and parameterize threshold tests

### DIFF
--- a/src/test/frontend/components/activity/ActivityCard.test.tsx
+++ b/src/test/frontend/components/activity/ActivityCard.test.tsx
@@ -10,16 +10,15 @@ import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import ActivityCard from 'Frontend/components/activity/ActivityCard';
 import type { ActivityCardConfig } from 'Frontend/components/activity';
+import { createMockActivityCardConfig } from '../../fixtures/mockFactories';
 
 expect.extend(toHaveNoViolations);
 
-const mockConfig: ActivityCardConfig = {
-  id: 'test-card',
-  type: 'solar-indices',
-  size: '1x1',
+// Use shared factory with test-specific defaults
+const mockConfig: ActivityCardConfig = createMockActivityCardConfig({
   priority: 75,
   hotness: 'hot',
-};
+});
 
 describe('ActivityCard', () => {
   describe('rendering', () => {

--- a/src/test/frontend/components/activity/ActivityGrid.test.tsx
+++ b/src/test/frontend/components/activity/ActivityGrid.test.tsx
@@ -11,21 +11,17 @@ import { axe, toHaveNoViolations } from 'jest-axe';
 import ActivityGrid from 'Frontend/components/activity/ActivityGrid';
 import ActivityCard from 'Frontend/components/activity/ActivityCard';
 import type { ActivityCardConfig } from 'Frontend/components/activity';
+import { createMockActivityCardConfig } from '../../fixtures/mockFactories';
 
 expect.extend(toHaveNoViolations);
 
+// Wrapper to maintain existing test API while using shared factory
 const createCard = (
   id: string,
   priority: number,
   hotness: 'hot' | 'warm' | 'neutral' | 'cool',
   size: '1x1' | '2x1' | '1x2' | '2x2' = '1x1',
-): ActivityCardConfig => ({
-  id,
-  type: 'solar-indices',
-  size,
-  priority,
-  hotness,
-});
+): ActivityCardConfig => createMockActivityCardConfig({ id, priority, hotness, size });
 
 describe('ActivityGrid', () => {
   describe('rendering', () => {

--- a/src/test/frontend/components/activity/ActivitySystem.a11y.test.tsx
+++ b/src/test/frontend/components/activity/ActivitySystem.a11y.test.tsx
@@ -12,17 +12,14 @@ import { axe, toHaveNoViolations } from 'jest-axe';
 import ActivityGrid from 'Frontend/components/activity/ActivityGrid';
 import ActivityCard from 'Frontend/components/activity/ActivityCard';
 import type { ActivityCardConfig } from 'Frontend/components/activity';
+import { createMockActivityCardConfig } from '../../fixtures/mockFactories';
 
 expect.extend(toHaveNoViolations);
 
+// Helper using shared factory with computed hotness
 const createTestCard = (id: string, priority: number, title: string, interactive = false) => {
-  const config: ActivityCardConfig = {
-    id,
-    type: 'solar-indices',
-    size: '1x1',
-    priority,
-    hotness: priority >= 70 ? 'hot' : priority >= 45 ? 'warm' : 'neutral',
-  };
+  const hotness = priority >= 70 ? 'hot' : priority >= 45 ? 'warm' : 'neutral';
+  const config = createMockActivityCardConfig({ id, priority, hotness });
 
   return {
     config,

--- a/src/test/frontend/components/cards/activations/ActivationsContent.test.tsx
+++ b/src/test/frontend/components/cards/activations/ActivationsContent.test.tsx
@@ -3,37 +3,50 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import ActivationsContent from 'Frontend/components/cards/activations/ActivationsContent';
 import type Activation from 'Frontend/generated/io/nextskip/activations/model/Activation';
+import { createMockActivation } from '../../../fixtures/mockFactories';
 
 describe('ActivationsContent', () => {
-  /* eslint-disable @typescript-eslint/max-params */
-  const createActivation = (
-    id: number,
-    callsign: string,
-    reference: string,
-    frequency: number,
-    mode: string,
-    name?: string,
-    regionCode?: string,
-  ): Activation => ({
-    spotId: String(id),
-    activatorCallsign: callsign,
-    location: {
-      reference,
-      name,
-      regionCode,
-    },
-    frequency,
-    mode,
-    spottedAt: new Date().toISOString(),
-    favorable: true,
-    score: 75,
-  });
+  // Helper to create activation with specific test values
+  interface ActivationParams {
+    id: number;
+    callsign: string;
+    reference: string;
+    frequency: number;
+    mode: string;
+    name?: string;
+    regionCode?: string;
+  }
+
+  const createActivation = (params: ActivationParams): Activation =>
+    createMockActivation({
+      spotId: String(params.id),
+      activatorCallsign: params.callsign,
+      frequency: params.frequency,
+      mode: params.mode,
+      location: { reference: params.reference, name: params.name, regionCode: params.regionCode },
+    });
 
   describe('POTA type', () => {
     it('should render activation count', () => {
       const activations = [
-        createActivation(1, 'K1ABC', 'K-1234', 14250, 'SSB', 'Test Park', 'US-MA'),
-        createActivation(2, 'W2XYZ', 'K-5678', 7074, 'FT8', 'Another Park', 'US-NY'),
+        createActivation({
+          id: 1,
+          callsign: 'K1ABC',
+          reference: 'K-1234',
+          frequency: 14250,
+          mode: 'SSB',
+          name: 'Test Park',
+          regionCode: 'US-MA',
+        }),
+        createActivation({
+          id: 2,
+          callsign: 'W2XYZ',
+          reference: 'K-5678',
+          frequency: 7074,
+          mode: 'FT8',
+          name: 'Another Park',
+          regionCode: 'US-NY',
+        }),
       ];
 
       render(<ActivationsContent activations={activations} type="pota" emptyMessage="No activations" />);
@@ -43,7 +56,17 @@ describe('ActivationsContent', () => {
     });
 
     it('should render activation list', () => {
-      const activations = [createActivation(1, 'K1ABC', 'K-1234', 14250, 'SSB', 'Test Park', 'US-MA')];
+      const activations = [
+        createActivation({
+          id: 1,
+          callsign: 'K1ABC',
+          reference: 'K-1234',
+          frequency: 14250,
+          mode: 'SSB',
+          name: 'Test Park',
+          regionCode: 'US-MA',
+        }),
+      ];
 
       render(<ActivationsContent activations={activations} type="pota" emptyMessage="No activations" />);
 
@@ -55,7 +78,9 @@ describe('ActivationsContent', () => {
     });
 
     it('should use pota-content class', () => {
-      const activations = [createActivation(1, 'K1ABC', 'K-1234', 14250, 'SSB')];
+      const activations = [
+        createActivation({ id: 1, callsign: 'K1ABC', reference: 'K-1234', frequency: 14250, mode: 'SSB' }),
+      ];
 
       const { container } = render(
         <ActivationsContent activations={activations} type="pota" emptyMessage="No activations" />,
@@ -65,7 +90,16 @@ describe('ActivationsContent', () => {
     });
 
     it('should use park-name class for location', () => {
-      const activations = [createActivation(1, 'K1ABC', 'K-1234', 14250, 'SSB', 'Test Park')];
+      const activations = [
+        createActivation({
+          id: 1,
+          callsign: 'K1ABC',
+          reference: 'K-1234',
+          frequency: 14250,
+          mode: 'SSB',
+          name: 'Test Park',
+        }),
+      ];
 
       const { container } = render(
         <ActivationsContent activations={activations} type="pota" emptyMessage="No activations" />,
@@ -78,8 +112,24 @@ describe('ActivationsContent', () => {
   describe('SOTA type', () => {
     it('should render activation count', () => {
       const activations = [
-        createActivation(1, 'G4ABC', 'W7W/SE-001', 14250, 'CW', 'Mount Rainier', 'US-WA'),
-        createActivation(2, 'K5XYZ', 'W7W/SE-002', 7074, 'FT8', 'Mount Adams', 'US-WA'),
+        createActivation({
+          id: 1,
+          callsign: 'G4ABC',
+          reference: 'W7W/SE-001',
+          frequency: 14250,
+          mode: 'CW',
+          name: 'Mount Rainier',
+          regionCode: 'US-WA',
+        }),
+        createActivation({
+          id: 2,
+          callsign: 'K5XYZ',
+          reference: 'W7W/SE-002',
+          frequency: 7074,
+          mode: 'FT8',
+          name: 'Mount Adams',
+          regionCode: 'US-WA',
+        }),
       ];
 
       render(<ActivationsContent activations={activations} type="sota" emptyMessage="No activations" />);
@@ -89,7 +139,9 @@ describe('ActivationsContent', () => {
     });
 
     it('should use sota-content class', () => {
-      const activations = [createActivation(1, 'G4ABC', 'W7W/SE-001', 14250, 'CW')];
+      const activations = [
+        createActivation({ id: 1, callsign: 'G4ABC', reference: 'W7W/SE-001', frequency: 14250, mode: 'CW' }),
+      ];
 
       const { container } = render(
         <ActivationsContent activations={activations} type="sota" emptyMessage="No activations" />,
@@ -99,7 +151,16 @@ describe('ActivationsContent', () => {
     });
 
     it('should use summit-name class for location', () => {
-      const activations = [createActivation(1, 'G4ABC', 'W7W/SE-001', 14250, 'CW', 'Mount Rainier')];
+      const activations = [
+        createActivation({
+          id: 1,
+          callsign: 'G4ABC',
+          reference: 'W7W/SE-001',
+          frequency: 14250,
+          mode: 'CW',
+          name: 'Mount Rainier',
+        }),
+      ];
 
       const { container } = render(
         <ActivationsContent activations={activations} type="sota" emptyMessage="No activations" />,
@@ -125,7 +186,9 @@ describe('ActivationsContent', () => {
 
   describe('activation display', () => {
     it('should show callsign link to QRZ', () => {
-      const activations = [createActivation(1, 'K1ABC', 'K-1234', 14250, 'SSB')];
+      const activations = [
+        createActivation({ id: 1, callsign: 'K1ABC', reference: 'K-1234', frequency: 14250, mode: 'SSB' }),
+      ];
 
       render(<ActivationsContent activations={activations} type="pota" emptyMessage="No activations" />);
 
@@ -136,8 +199,20 @@ describe('ActivationsContent', () => {
     });
 
     it('should show mode or Unknown', () => {
-      const withMode = createActivation(1, 'K1ABC', 'K-1234', 14250, 'SSB');
-      const withoutMode = createActivation(2, 'W2XYZ', 'K-5678', 7074, '');
+      const withMode = createActivation({
+        id: 1,
+        callsign: 'K1ABC',
+        reference: 'K-1234',
+        frequency: 14250,
+        mode: 'SSB',
+      });
+      const withoutMode = createActivation({
+        id: 2,
+        callsign: 'W2XYZ',
+        reference: 'K-5678',
+        frequency: 7074,
+        mode: '',
+      });
 
       const { rerender } = render(
         <ActivationsContent activations={[withMode]} type="pota" emptyMessage="No activations" />,
@@ -151,7 +226,17 @@ describe('ActivationsContent', () => {
     });
 
     it('should render location with region code', () => {
-      const activations = [createActivation(1, 'K1ABC', 'K-1234', 14250, 'SSB', 'Test Park', 'US-MA')];
+      const activations = [
+        createActivation({
+          id: 1,
+          callsign: 'K1ABC',
+          reference: 'K-1234',
+          frequency: 14250,
+          mode: 'SSB',
+          name: 'Test Park',
+          regionCode: 'US-MA',
+        }),
+      ];
 
       render(<ActivationsContent activations={activations} type="pota" emptyMessage="No activations" />);
 
@@ -159,7 +244,16 @@ describe('ActivationsContent', () => {
     });
 
     it('should render location without region code', () => {
-      const activations = [createActivation(1, 'K1ABC', 'K-1234', 14250, 'SSB', 'Test Park')];
+      const activations = [
+        createActivation({
+          id: 1,
+          callsign: 'K1ABC',
+          reference: 'K-1234',
+          frequency: 14250,
+          mode: 'SSB',
+          name: 'Test Park',
+        }),
+      ];
 
       render(<ActivationsContent activations={activations} type="pota" emptyMessage="No activations" />);
 
@@ -167,7 +261,9 @@ describe('ActivationsContent', () => {
     });
 
     it('should not render location if name is missing', () => {
-      const activations = [createActivation(1, 'K1ABC', 'K-1234', 14250, 'SSB')];
+      const activations = [
+        createActivation({ id: 1, callsign: 'K1ABC', reference: 'K-1234', frequency: 14250, mode: 'SSB' }),
+      ];
 
       const { container } = render(
         <ActivationsContent activations={activations} type="pota" emptyMessage="No activations" />,
@@ -180,7 +276,9 @@ describe('ActivationsContent', () => {
 
   describe('pagination', () => {
     it('should show max 8 activations', () => {
-      const activations = Array.from({ length: 10 }, (_, i) => createActivation(i, `K${i}ABC`, `K-${i}`, 14250, 'SSB'));
+      const activations = Array.from({ length: 10 }, (_, i) =>
+        createActivation({ id: i, callsign: `K${i}ABC`, reference: `K-${i}`, frequency: 14250, mode: 'SSB' }),
+      );
 
       render(<ActivationsContent activations={activations} type="pota" emptyMessage="No activations" />);
 
@@ -195,7 +293,9 @@ describe('ActivationsContent', () => {
     });
 
     it('should show "more activations" message when > 8', () => {
-      const activations = Array.from({ length: 12 }, (_, i) => createActivation(i, `K${i}ABC`, `K-${i}`, 14250, 'SSB'));
+      const activations = Array.from({ length: 12 }, (_, i) =>
+        createActivation({ id: i, callsign: `K${i}ABC`, reference: `K-${i}`, frequency: 14250, mode: 'SSB' }),
+      );
 
       render(<ActivationsContent activations={activations} type="pota" emptyMessage="No activations" />);
 
@@ -203,7 +303,9 @@ describe('ActivationsContent', () => {
     });
 
     it('should not show "more activations" when <= 8', () => {
-      const activations = Array.from({ length: 8 }, (_, i) => createActivation(i, `K${i}ABC`, `K-${i}`, 14250, 'SSB'));
+      const activations = Array.from({ length: 8 }, (_, i) =>
+        createActivation({ id: i, callsign: `K${i}ABC`, reference: `K-${i}`, frequency: 14250, mode: 'SSB' }),
+      );
 
       render(<ActivationsContent activations={activations} type="pota" emptyMessage="No activations" />);
 
@@ -213,7 +315,9 @@ describe('ActivationsContent', () => {
 
   describe('memoization', () => {
     it('should memoize displayActivations', () => {
-      const activations = Array.from({ length: 10 }, (_, i) => createActivation(i, `K${i}ABC`, `K-${i}`, 14250, 'SSB'));
+      const activations = Array.from({ length: 10 }, (_, i) =>
+        createActivation({ id: i, callsign: `K${i}ABC`, reference: `K-${i}`, frequency: 14250, mode: 'SSB' }),
+      );
 
       const { rerender } = render(
         <ActivationsContent activations={activations} type="pota" emptyMessage="No activations" />,

--- a/src/test/frontend/components/cards/activations/PotaActivationsContent.test.tsx
+++ b/src/test/frontend/components/cards/activations/PotaActivationsContent.test.tsx
@@ -2,37 +2,17 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import PotaActivationsContent from 'Frontend/components/cards/activations/PotaActivationsContent';
-import type Activation from 'Frontend/generated/io/nextskip/activations/model/Activation';
-import ActivationType from 'Frontend/generated/io/nextskip/activations/model/ActivationType';
+import { createMockPotaActivation } from '../../../fixtures/mockFactories';
 
 // Extend Vitest's expect with jest-axe matchers
 expect.extend(toHaveNoViolations);
 
 describe('PotaActivationsContent', () => {
-  const createMockActivation = (overrides?: Partial<Activation>): Activation => ({
-    spotId: '123456',
-    activatorCallsign: 'W1ABC',
-    type: ActivationType.POTA,
-    frequency: 14250,
-    mode: 'SSB',
-    spottedAt: new Date().toISOString(),
-    qsoCount: 15,
-    source: 'POTA API',
-    location: {
-      reference: 'US-0001',
-      name: 'Test Park',
-      regionCode: 'MA',
-    },
-    favorable: true,
-    score: 75,
-    ...overrides,
-  });
-
   it('should render activation count', () => {
     const activations = [
-      createMockActivation({ spotId: '1' }),
-      createMockActivation({ spotId: '2' }),
-      createMockActivation({ spotId: '3' }),
+      createMockPotaActivation({ spotId: '1' }),
+      createMockPotaActivation({ spotId: '2' }),
+      createMockPotaActivation({ spotId: '3' }),
     ];
 
     render(<PotaActivationsContent activations={activations} />);
@@ -42,7 +22,7 @@ describe('PotaActivationsContent', () => {
   });
 
   it('should display callsign with QRZ link', () => {
-    const activations = [createMockActivation()];
+    const activations = [createMockPotaActivation()];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -54,7 +34,7 @@ describe('PotaActivationsContent', () => {
 
   it('should display park reference and name', () => {
     const activations = [
-      createMockActivation({
+      createMockPotaActivation({
         location: {
           reference: 'US-0001',
           name: 'Yellowstone National Park',
@@ -71,7 +51,7 @@ describe('PotaActivationsContent', () => {
 
   it('should display frequency and mode', () => {
     const activations = [
-      createMockActivation({
+      createMockPotaActivation({
         frequency: 14250,
         mode: 'SSB',
       }),
@@ -85,7 +65,7 @@ describe('PotaActivationsContent', () => {
 
   it('should format frequency correctly', () => {
     const activations = [
-      createMockActivation({ frequency: 7200 }), // 7.200 MHz
+      createMockPotaActivation({ frequency: 7200 }), // 7.200 MHz
     ];
 
     render(<PotaActivationsContent activations={activations} />);
@@ -107,7 +87,7 @@ describe('PotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const fiveMinutesAgo = new Date('2025-01-15T11:55:00Z');
-    const activations = [createMockActivation({ spottedAt: fiveMinutesAgo.toISOString() })];
+    const activations = [createMockPotaActivation({ spottedAt: fiveMinutesAgo.toISOString() })];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -119,7 +99,7 @@ describe('PotaActivationsContent', () => {
 
   it('should limit display to 8 activations with overflow message', () => {
     const manyActivations = Array.from({ length: 10 }, (_, i) =>
-      createMockActivation({ spotId: `${i + 1}`, activatorCallsign: `W${i}ABC` }),
+      createMockPotaActivation({ spotId: `${i + 1}`, activatorCallsign: `W${i}ABC` }),
     );
 
     render(<PotaActivationsContent activations={manyActivations} />);
@@ -137,7 +117,7 @@ describe('PotaActivationsContent', () => {
 
   it('should be WCAG 2.1 AA compliant', async () => {
     const activations = [
-      createMockActivation({
+      createMockPotaActivation({
         spotId: '1',
         activatorCallsign: 'W1ABC',
         location: {
@@ -159,7 +139,7 @@ describe('PotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const thirtySecondsAgo = new Date('2025-01-15T11:59:30Z');
-    const activations = [createMockActivation({ spottedAt: thirtySecondsAgo.toISOString() })];
+    const activations = [createMockPotaActivation({ spottedAt: thirtySecondsAgo.toISOString() })];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -173,7 +153,7 @@ describe('PotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const oneMinuteAgo = new Date('2025-01-15T11:59:00Z');
-    const activations = [createMockActivation({ spottedAt: oneMinuteAgo.toISOString() })];
+    const activations = [createMockPotaActivation({ spottedAt: oneMinuteAgo.toISOString() })];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -187,7 +167,7 @@ describe('PotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const twoHoursAgo = new Date('2025-01-15T10:00:00Z');
-    const activations = [createMockActivation({ spottedAt: twoHoursAgo.toISOString() })];
+    const activations = [createMockPotaActivation({ spottedAt: twoHoursAgo.toISOString() })];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -201,7 +181,7 @@ describe('PotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const oneHourAgo = new Date('2025-01-15T11:00:00Z');
-    const activations = [createMockActivation({ spottedAt: oneHourAgo.toISOString() })];
+    const activations = [createMockPotaActivation({ spottedAt: oneHourAgo.toISOString() })];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -211,7 +191,7 @@ describe('PotaActivationsContent', () => {
   });
 
   it('should display "Unknown" for null timestamp', () => {
-    const activations = [createMockActivation({ spottedAt: undefined })];
+    const activations = [createMockPotaActivation({ spottedAt: undefined })];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -219,7 +199,7 @@ describe('PotaActivationsContent', () => {
   });
 
   it('should display "Unknown" for null frequency', () => {
-    const activations = [createMockActivation({ frequency: undefined })];
+    const activations = [createMockPotaActivation({ frequency: undefined })];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -228,7 +208,7 @@ describe('PotaActivationsContent', () => {
 
   it('should handle missing park name gracefully', () => {
     const activations = [
-      createMockActivation({
+      createMockPotaActivation({
         location: {
           reference: 'US-0001',
           name: undefined,
@@ -244,7 +224,7 @@ describe('PotaActivationsContent', () => {
   });
 
   it('should display "Unknown" for null mode', () => {
-    const activations = [createMockActivation({ mode: undefined })];
+    const activations = [createMockPotaActivation({ mode: undefined })];
 
     render(<PotaActivationsContent activations={activations} />);
 

--- a/src/test/frontend/components/cards/propagation/BandRatingDisplay.test.tsx
+++ b/src/test/frontend/components/cards/propagation/BandRatingDisplay.test.tsx
@@ -5,20 +5,13 @@ import { axe, toHaveNoViolations } from 'jest-axe';
 import { BandRatingDisplay } from 'Frontend/components/cards/propagation/BandRatingDisplay';
 import type BandCondition from 'Frontend/generated/io/nextskip/propagation/model/BandCondition';
 import BandConditionRating from 'Frontend/generated/io/nextskip/propagation/model/BandConditionRating';
-import FrequencyBand from 'Frontend/generated/io/nextskip/common/model/FrequencyBand';
+import { createMockBandCondition } from '../../../fixtures/mockFactories';
 
 expect.extend(toHaveNoViolations);
 
 describe('BandRatingDisplay', () => {
-  const createCondition = (overrides?: Partial<BandCondition>): BandCondition => ({
-    band: FrequencyBand.BAND_20M,
-    rating: BandConditionRating.GOOD,
-    confidence: 1.0,
-    notes: undefined,
-    favorable: true,
-    score: 100,
-    ...overrides,
-  });
+  // Use shared factory - alias for backward compatibility
+  const createCondition = createMockBandCondition;
 
   describe('rendering', () => {
     it('should render the rating badge', () => {
@@ -31,36 +24,17 @@ describe('BandRatingDisplay', () => {
   });
 
   describe('rating badges', () => {
-    it('should render GOOD rating with correct class', () => {
-      const condition = createCondition({ rating: BandConditionRating.GOOD });
+    it.each([
+      [BandConditionRating.GOOD, 'GOOD', '.rating-good'],
+      [BandConditionRating.FAIR, 'FAIR', '.rating-fair'],
+      [BandConditionRating.POOR, 'POOR', '.rating-poor'],
+      [BandConditionRating.UNKNOWN, 'UNKNOWN', '.rating-unknown'],
+    ])('should render %s rating with correct class', (rating, expectedText, expectedClass) => {
+      const condition = createCondition({ rating });
       const { container } = render(<BandRatingDisplay condition={condition} />);
 
-      expect(screen.getByText('GOOD')).toBeInTheDocument();
-      expect(container.querySelector('.rating-good')).toBeInTheDocument();
-    });
-
-    it('should render FAIR rating with correct class', () => {
-      const condition = createCondition({ rating: BandConditionRating.FAIR, score: 60 });
-      const { container } = render(<BandRatingDisplay condition={condition} />);
-
-      expect(screen.getByText('FAIR')).toBeInTheDocument();
-      expect(container.querySelector('.rating-fair')).toBeInTheDocument();
-    });
-
-    it('should render POOR rating with correct class', () => {
-      const condition = createCondition({ rating: BandConditionRating.POOR, score: 20 });
-      const { container } = render(<BandRatingDisplay condition={condition} />);
-
-      expect(screen.getByText('POOR')).toBeInTheDocument();
-      expect(container.querySelector('.rating-poor')).toBeInTheDocument();
-    });
-
-    it('should render UNKNOWN rating with correct class', () => {
-      const condition = createCondition({ rating: BandConditionRating.UNKNOWN, score: 0 });
-      const { container } = render(<BandRatingDisplay condition={condition} />);
-
-      expect(screen.getByText('UNKNOWN')).toBeInTheDocument();
-      expect(container.querySelector('.rating-unknown')).toBeInTheDocument();
+      expect(screen.getByText(expectedText)).toBeInTheDocument();
+      expect(container.querySelector(expectedClass)).toBeInTheDocument();
     });
 
     it('should handle undefined rating gracefully', () => {
@@ -73,25 +47,12 @@ describe('BandRatingDisplay', () => {
   });
 
   describe('rating icons', () => {
-    it('should render Check icon for GOOD rating', () => {
-      const condition = createCondition({ rating: BandConditionRating.GOOD });
-      const { container } = render(<BandRatingDisplay condition={condition} />);
-
-      // lucide-react renders SVG with data-lucide attribute
-      const icon = container.querySelector('.rating-icon svg');
-      expect(icon).toBeInTheDocument();
-    });
-
-    it('should render Minus icon for FAIR rating', () => {
-      const condition = createCondition({ rating: BandConditionRating.FAIR });
-      const { container } = render(<BandRatingDisplay condition={condition} />);
-
-      const icon = container.querySelector('.rating-icon svg');
-      expect(icon).toBeInTheDocument();
-    });
-
-    it('should render X icon for POOR rating', () => {
-      const condition = createCondition({ rating: BandConditionRating.POOR });
+    it.each([
+      [BandConditionRating.GOOD, 'Check'],
+      [BandConditionRating.FAIR, 'Minus'],
+      [BandConditionRating.POOR, 'X'],
+    ])('should render SVG icon for %s rating', (rating) => {
+      const condition = createCondition({ rating });
       const { container } = render(<BandRatingDisplay condition={condition} />);
 
       const icon = container.querySelector('.rating-icon svg');

--- a/src/test/frontend/components/cards/propagation/SolarIndicesContent.test.tsx
+++ b/src/test/frontend/components/cards/propagation/SolarIndicesContent.test.tsx
@@ -3,18 +3,12 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import SolarIndicesContent from 'Frontend/components/cards/propagation/SolarIndicesContent';
 import type SolarIndices from 'Frontend/generated/io/nextskip/propagation/model/SolarIndices';
+import { createMockSolarIndices } from '../../../fixtures/mockFactories';
 
 describe('SolarIndicesContent', () => {
-  const createIndices = (overrides?: Partial<SolarIndices>): SolarIndices => ({
-    solarFluxIndex: 150,
-    kIndex: 2,
-    aIndex: 15,
-    sunspotNumber: 75,
-    favorable: true,
-    score: 80,
-    source: 'Test Source',
-    ...overrides,
-  });
+  // Create a wrapper with test-specific defaults (SFI=150 to match existing tests)
+  const createIndices = (overrides?: Partial<SolarIndices>): SolarIndices =>
+    createMockSolarIndices({ solarFluxIndex: 150, sunspotNumber: 75, ...overrides });
 
   describe('rendering', () => {
     it('should render all index labels', () => {
@@ -34,9 +28,9 @@ describe('SolarIndicesContent', () => {
       render(<SolarIndicesContent solarIndices={indices} />);
 
       expect(screen.getByText('150.5')).toBeInTheDocument();
-      expect(screen.getByText('2')).toBeInTheDocument();
-      expect(screen.getByText('15')).toBeInTheDocument();
-      expect(screen.getByText('75')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument(); // K-index
+      expect(screen.getByText('10')).toBeInTheDocument(); // A-index (from shared factory default)
+      expect(screen.getByText('75')).toBeInTheDocument(); // Sunspot
     });
 
     it('should display N/A for undefined values', () => {
@@ -63,44 +57,18 @@ describe('SolarIndicesContent', () => {
       expect(screen.getByText('142.7')).toBeInTheDocument();
     });
 
-    it('should show Very High status for SFI >= 200', () => {
-      const indices = createIndices({ solarFluxIndex: 200 });
+    it.each([
+      [200, 'Very High'],
+      [150, 'High'],
+      [100, 'Moderate'],
+      [70, 'Low'],
+      [50, 'Very Low'],
+    ])('should show %s status for SFI=%d', (sfi, expectedStatus) => {
+      const indices = createIndices({ solarFluxIndex: sfi });
 
       render(<SolarIndicesContent solarIndices={indices} />);
 
-      expect(screen.getByText('Very High')).toBeInTheDocument();
-    });
-
-    it('should show High status for SFI >= 150', () => {
-      const indices = createIndices();
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('High')).toBeInTheDocument();
-    });
-
-    it('should show Moderate status for SFI >= 100', () => {
-      const indices = createIndices({ solarFluxIndex: 100 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Moderate')).toBeInTheDocument();
-    });
-
-    it('should show Low status for SFI >= 70', () => {
-      const indices = createIndices({ solarFluxIndex: 70 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Low')).toBeInTheDocument();
-    });
-
-    it('should show Very Low status for SFI < 70', () => {
-      const indices = createIndices({ solarFluxIndex: 50 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Very Low')).toBeInTheDocument();
+      expect(screen.getByText(expectedStatus)).toBeInTheDocument();
     });
 
     it('should apply status-good class for high SFI', () => {
@@ -121,52 +89,19 @@ describe('SolarIndicesContent', () => {
   });
 
   describe('K-Index', () => {
-    it('should show Quiet status for K=0', () => {
-      const indices = createIndices({ kIndex: 0 });
+    it.each([
+      [0, 'Quiet'],
+      [2, 'Settled'],
+      [4, 'Unsettled'],
+      [6, 'Active'],
+      [8, 'Storm'],
+      [9, 'Severe Storm'],
+    ])('should show %s status for K=%d', (kIndex, expectedStatus) => {
+      const indices = createIndices({ kIndex });
 
       render(<SolarIndicesContent solarIndices={indices} />);
 
-      expect(screen.getByText('Quiet')).toBeInTheDocument();
-    });
-
-    it('should show Settled status for K=1-2', () => {
-      const indices = createIndices();
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Settled')).toBeInTheDocument();
-    });
-
-    it('should show Unsettled status for K=3-4', () => {
-      const indices = createIndices({ kIndex: 4 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Unsettled')).toBeInTheDocument();
-    });
-
-    it('should show Active status for K=5-6', () => {
-      const indices = createIndices({ kIndex: 6 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Active')).toBeInTheDocument();
-    });
-
-    it('should show Storm status for K=7-8', () => {
-      const indices = createIndices({ kIndex: 8 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Storm')).toBeInTheDocument();
-    });
-
-    it('should show Severe Storm status for K>=9', () => {
-      const indices = createIndices({ kIndex: 9 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Severe Storm')).toBeInTheDocument();
+      expect(screen.getByText(expectedStatus)).toBeInTheDocument();
     });
 
     it('should apply status-good class for low K-index', () => {
@@ -187,28 +122,19 @@ describe('SolarIndicesContent', () => {
   });
 
   describe('A-Index', () => {
-    it('should show "Quiet conditions" for A-index < 20', () => {
-      const indices = createIndices();
+    it.each([
+      [0, 'Quiet conditions'],
+      [15, 'Quiet conditions'],
+      [20, 'Unsettled conditions'],
+      [30, 'Unsettled conditions'],
+      [50, 'Disturbed conditions'],
+      [60, 'Disturbed conditions'],
+    ])('should show "%s" for A-index=%d', (aIndex, expectedStatus) => {
+      const indices = createIndices({ aIndex });
 
       render(<SolarIndicesContent solarIndices={indices} />);
 
-      expect(screen.getByText('Quiet conditions')).toBeInTheDocument();
-    });
-
-    it('should show "Unsettled conditions" for A-index 20-49', () => {
-      const indices = createIndices({ aIndex: 30 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Unsettled conditions')).toBeInTheDocument();
-    });
-
-    it('should show "Disturbed conditions" for A-index >= 50', () => {
-      const indices = createIndices({ aIndex: 60 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Disturbed conditions')).toBeInTheDocument();
+      expect(screen.getByText(expectedStatus)).toBeInTheDocument();
     });
 
     it('should show "Disturbed conditions" when A-index is undefined', () => {
@@ -219,56 +145,24 @@ describe('SolarIndicesContent', () => {
 
       expect(screen.getByText('Disturbed conditions')).toBeInTheDocument();
     });
-
-    it('should handle A-index of 0', () => {
-      const indices = createIndices({ aIndex: 0 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('0')).toBeInTheDocument();
-      expect(screen.getByText('Quiet conditions')).toBeInTheDocument();
-    });
-
-    it('should handle boundary value 20', () => {
-      const indices = createIndices({ aIndex: 20 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Unsettled conditions')).toBeInTheDocument();
-    });
-
-    it('should handle boundary value 50', () => {
-      const indices = createIndices({ aIndex: 50 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Disturbed conditions')).toBeInTheDocument();
-    });
   });
 
   describe('Sunspot Number', () => {
-    it('should show "High solar activity" for sunspots > 100', () => {
-      const indices = createIndices({ sunspotNumber: 150 });
+    it.each([
+      [0, 'Low solar activity'],
+      [30, 'Low solar activity'],
+      [50, 'Low solar activity'],
+      [51, 'Moderate activity'],
+      [75, 'Moderate activity'],
+      [100, 'Moderate activity'],
+      [101, 'High solar activity'],
+      [150, 'High solar activity'],
+    ])('should show "%s" for sunspot=%d', (sunspotNumber, expectedStatus) => {
+      const indices = createIndices({ sunspotNumber });
 
       render(<SolarIndicesContent solarIndices={indices} />);
 
-      expect(screen.getByText('High solar activity')).toBeInTheDocument();
-    });
-
-    it('should show "Moderate activity" for sunspots 51-100', () => {
-      const indices = createIndices();
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Moderate activity')).toBeInTheDocument();
-    });
-
-    it('should show "Low solar activity" for sunspots <= 50', () => {
-      const indices = createIndices({ sunspotNumber: 30 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Low solar activity')).toBeInTheDocument();
+      expect(screen.getByText(expectedStatus)).toBeInTheDocument();
     });
 
     it('should show "Low solar activity" when sunspots is undefined', () => {
@@ -278,47 +172,6 @@ describe('SolarIndicesContent', () => {
       render(<SolarIndicesContent solarIndices={indices} />);
 
       expect(screen.getByText('Low solar activity')).toBeInTheDocument();
-    });
-
-    it('should handle sunspot number of 0', () => {
-      const indices = createIndices({ sunspotNumber: 0 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('0')).toBeInTheDocument();
-      expect(screen.getByText('Low solar activity')).toBeInTheDocument();
-    });
-
-    it('should handle boundary value 50', () => {
-      const indices = createIndices({ sunspotNumber: 50 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Low solar activity')).toBeInTheDocument();
-    });
-
-    it('should handle boundary value 51', () => {
-      const indices = createIndices({ sunspotNumber: 51 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Moderate activity')).toBeInTheDocument();
-    });
-
-    it('should handle boundary value 100', () => {
-      const indices = createIndices({ sunspotNumber: 100 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('Moderate activity')).toBeInTheDocument();
-    });
-
-    it('should handle boundary value 101', () => {
-      const indices = createIndices({ sunspotNumber: 101 });
-
-      render(<SolarIndicesContent solarIndices={indices} />);
-
-      expect(screen.getByText('High solar activity')).toBeInTheDocument();
     });
   });
 

--- a/src/test/frontend/fixtures/mockFactories.ts
+++ b/src/test/frontend/fixtures/mockFactories.ts
@@ -283,7 +283,34 @@ export function createPoorBandCondition(band: FrequencyBand): BandCondition {
 }
 
 // =============================================================================
-// Card Factory (for dashboard card testing)
+// ActivityCardConfig Factory (for grid and card component testing)
+// =============================================================================
+
+// Import the actual type from main frontend code
+import type { ActivityCardConfig } from 'Frontend/types/activity';
+
+/**
+ * Creates a mock ActivityCardConfig with sensible defaults.
+ *
+ * @param overrides - Optional partial ActivityCardConfig to override defaults
+ * @returns A complete ActivityCardConfig object
+ */
+export function createMockActivityCardConfig(overrides?: Partial<ActivityCardConfig>): ActivityCardConfig {
+  return {
+    id: 'test-card',
+    type: 'solar-indices',
+    size: '1x1',
+    priority: 50,
+    hotness: 'neutral',
+    ...overrides,
+  };
+}
+
+// Re-export the type for convenience
+export type { ActivityCardConfig };
+
+// =============================================================================
+// Card Factory (for priority calculation testing)
 // =============================================================================
 
 /**

--- a/src/test/frontend/utils/activations.test.ts
+++ b/src/test/frontend/utils/activations.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { formatFrequency, formatTimeSince } from 'Frontend/utils/activations';
+import { formatFrequency } from 'Frontend/utils/activations';
 
+/**
+ * Tests for activations-specific utilities.
+ * Note: formatTimeSince tests are in formatTime.test.ts (canonical location)
+ */
 describe('activations utilities', () => {
   describe('formatFrequency', () => {
     it('should format frequencies correctly', () => {
@@ -35,63 +39,6 @@ describe('activations utilities', () => {
 
     it('should handle null', () => {
       expect(formatFrequency(null as any)).toBe('Unknown');
-    });
-  });
-
-  describe('formatTimeSince', () => {
-    it('should format recent times as "Just now"', () => {
-      const now = new Date();
-      const thirtySecondsAgo = new Date(now.getTime() - 30000).toISOString();
-      expect(formatTimeSince(thirtySecondsAgo)).toBe('Just now');
-    });
-
-    it('should format 1 minute ago', () => {
-      const now = new Date();
-      const oneMinuteAgo = new Date(now.getTime() - 60 * 1000).toISOString();
-      expect(formatTimeSince(oneMinuteAgo)).toBe('1 min ago');
-    });
-
-    it('should format minutes ago', () => {
-      const now = new Date();
-      const fiveMinutesAgo = new Date(now.getTime() - 5 * 60 * 1000).toISOString();
-      expect(formatTimeSince(fiveMinutesAgo)).toBe('5 min ago');
-
-      const fiftyNineMinutesAgo = new Date(now.getTime() - 59 * 60 * 1000).toISOString();
-      expect(formatTimeSince(fiftyNineMinutesAgo)).toBe('59 min ago');
-    });
-
-    it('should format 1 hour ago', () => {
-      const now = new Date();
-      const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000).toISOString();
-      expect(formatTimeSince(oneHourAgo)).toBe('1 hour ago');
-    });
-
-    it('should format hours ago', () => {
-      const now = new Date();
-      const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000).toISOString();
-      expect(formatTimeSince(twoHoursAgo)).toBe('2 hours ago');
-
-      const twentyThreeHoursAgo = new Date(now.getTime() - 23 * 60 * 60 * 1000).toISOString();
-      expect(formatTimeSince(twentyThreeHoursAgo)).toBe('23 hours ago');
-    });
-
-    it('should format many hours ago (no day conversion)', () => {
-      const now = new Date();
-      const threeDaysInHours = new Date(now.getTime() - 72 * 60 * 60 * 1000).toISOString();
-      expect(formatTimeSince(threeDaysInHours)).toBe('72 hours ago');
-    });
-
-    it('should handle undefined', () => {
-      expect(formatTimeSince(undefined)).toBe('Unknown');
-    });
-
-    it('should handle invalid date strings', () => {
-      // Invalid dates result in NaN calculations
-      expect(formatTimeSince('invalid')).toBe('NaN hours ago');
-    });
-
-    it('should handle empty string', () => {
-      expect(formatTimeSince('')).toBe('Unknown');
     });
   });
 });

--- a/src/test/java/io/nextskip/activations/internal/ActivationsServiceImplTest.java
+++ b/src/test/java/io/nextskip/activations/internal/ActivationsServiceImplTest.java
@@ -1,23 +1,24 @@
 package io.nextskip.activations.internal;
 
+import static io.nextskip.test.fixtures.ActivationFixtures.pota;
+import static io.nextskip.test.fixtures.ActivationFixtures.sota;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.nextskip.activations.model.Activation;
 import io.nextskip.activations.model.ActivationsSummary;
 import io.nextskip.activations.model.ActivationType;
 import io.nextskip.common.config.CacheConfig;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for ActivationsServiceImpl.
@@ -180,50 +181,13 @@ class ActivationsServiceImplTest {
      * Helper method to create a test POTA activation.
      */
     private Activation createPotaActivation(String id, String callsign) {
-        io.nextskip.activations.model.Park park = new io.nextskip.activations.model.Park(
-                "US-0001",
-                "Test Park",
-                "CO",
-                "US",
-                "FN42",
-                42.5,
-                -71.3
-        );
-
-        return new Activation(
-                id,
-                callsign,
-                ActivationType.POTA,
-                14250.0,
-                "SSB",
-                Instant.now(),
-                10,
-                "POTA API",
-                park
-        );
+        return pota().spotId(id).activatorCallsign(callsign).build();
     }
 
     /**
      * Helper method to create a test SOTA activation.
      */
     private Activation createSotaActivation(String id, String callsign) {
-        io.nextskip.activations.model.Summit summit = new io.nextskip.activations.model.Summit(
-                "W7W/LC-001",
-                "Test Summit",
-                "WA",
-                "W7W"
-        );
-
-        return new Activation(
-                id,
-                callsign,
-                ActivationType.SOTA,
-                7200.0,
-                "CW",
-                Instant.now(),
-                null,
-                "SOTA API",
-                summit
-        );
+        return sota().spotId(id).activatorCallsign(callsign).build();
     }
 }

--- a/src/test/java/io/nextskip/activations/internal/scheduler/PotaRefreshServiceTest.java
+++ b/src/test/java/io/nextskip/activations/internal/scheduler/PotaRefreshServiceTest.java
@@ -1,24 +1,6 @@
 package io.nextskip.activations.internal.scheduler;
 
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import io.nextskip.activations.internal.PotaClient;
-import io.nextskip.activations.model.Activation;
-import io.nextskip.activations.model.ActivationType;
-import io.nextskip.activations.model.Park;
-import io.nextskip.activations.persistence.entity.ActivationEntity;
-import io.nextskip.activations.persistence.repository.ActivationRepository;
-import io.nextskip.common.config.CacheConfig;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.Instant;
-import java.util.Collections;
-import java.util.List;
-
+import static io.nextskip.test.fixtures.ActivationFixtures.pota;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,6 +9,23 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import io.nextskip.activations.internal.PotaClient;
+import io.nextskip.activations.model.Activation;
+import io.nextskip.activations.model.ActivationType;
+import io.nextskip.activations.persistence.entity.ActivationEntity;
+import io.nextskip.activations.persistence.repository.ActivationRepository;
+import io.nextskip.common.config.CacheConfig;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit tests for PotaRefreshService.
@@ -159,26 +158,7 @@ class PotaRefreshServiceTest {
     }
 
     private Activation createTestActivation() {
-        Park park = new Park(
-                "K-1234",
-                "Test Park",
-                "CO",
-                "US",
-                "DM79",
-                40.0,
-                -105.0
-        );
-        return new Activation(
-                "spot-1234",
-                "W1ABC",
-                ActivationType.POTA,
-                14074.0,
-                "FT8",
-                Instant.now(),
-                5,
-                "POTA",
-                park
-        );
+        return pota().spotId("spot-1234").build();
     }
 
     private ActivationEntity createTestEntity() {

--- a/src/test/java/io/nextskip/activations/internal/scheduler/SotaRefreshServiceTest.java
+++ b/src/test/java/io/nextskip/activations/internal/scheduler/SotaRefreshServiceTest.java
@@ -1,24 +1,6 @@
 package io.nextskip.activations.internal.scheduler;
 
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import io.nextskip.activations.internal.SotaClient;
-import io.nextskip.activations.model.Activation;
-import io.nextskip.activations.model.ActivationType;
-import io.nextskip.activations.model.Summit;
-import io.nextskip.activations.persistence.entity.ActivationEntity;
-import io.nextskip.activations.persistence.repository.ActivationRepository;
-import io.nextskip.common.config.CacheConfig;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.Instant;
-import java.util.Collections;
-import java.util.List;
-
+import static io.nextskip.test.fixtures.ActivationFixtures.sota;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,6 +9,23 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import io.nextskip.activations.internal.SotaClient;
+import io.nextskip.activations.model.Activation;
+import io.nextskip.activations.model.ActivationType;
+import io.nextskip.activations.persistence.entity.ActivationEntity;
+import io.nextskip.activations.persistence.repository.ActivationRepository;
+import io.nextskip.common.config.CacheConfig;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit tests for SotaRefreshService.
@@ -159,23 +158,7 @@ class SotaRefreshServiceTest {
     }
 
     private Activation createTestActivation() {
-        Summit summit = new Summit(
-                "W4C/WM-001",
-                "Test Summit",
-                "NC",
-                "W4C"
-        );
-        return new Activation(
-                "spot-5678",
-                "W4ABC",
-                ActivationType.SOTA,
-                14285.0,
-                "SSB",
-                Instant.now(),
-                10,
-                "SOTA",
-                summit
-        );
+        return sota().spotId("spot-5678").activatorCallsign("W4ABC").build();
     }
 
     private ActivationEntity createTestEntity() {

--- a/src/test/java/io/nextskip/activations/model/ActivationTest.java
+++ b/src/test/java/io/nextskip/activations/model/ActivationTest.java
@@ -1,11 +1,11 @@
 package io.nextskip.activations.model;
 
-import org.junit.jupiter.api.Test;
+import static io.nextskip.test.fixtures.ActivationFixtures.pota;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for Activation model scoring logic.
@@ -184,26 +184,6 @@ class ActivationTest {
      * Helper method to create a test Activation.
      */
     private Activation createActivation(Instant spottedAt) {
-        io.nextskip.activations.model.Park park = new io.nextskip.activations.model.Park(
-                "US-0001",
-                "Test Park",
-                "CO",
-                "US",
-                "FN42",
-                42.5,
-                -71.3
-        );
-
-        return new Activation(
-                "12345",
-                "W1ABC",
-                ActivationType.POTA,
-                14250.0,
-                "SSB",
-                spottedAt,
-                10,
-                "Test Source",
-                park
-        );
+        return pota().spottedAt(spottedAt).build();
     }
 }

--- a/src/test/java/io/nextskip/propagation/model/SolarIndicesTest.java
+++ b/src/test/java/io/nextskip/propagation/model/SolarIndicesTest.java
@@ -1,12 +1,13 @@
 package io.nextskip.propagation.model;
 
-import org.junit.jupiter.api.Test;
-
-import java.time.Instant;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Comprehensive test suite for SolarIndices record.
@@ -29,120 +30,62 @@ class SolarIndicesTest {
     // Category 1: getGeomagneticActivity() - K-index to Activity Level Mapping
     // ==========================================================================
 
-    @Test
-    void testGetGeomagneticActivity_Quiet() {
-        // K-index 0-2 should return "Quiet"
-        var indices0 = new SolarIndices(100.0, 10, 0, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Quiet", indices0.getGeomagneticActivity());
+    @ParameterizedTest(name = "K-index {0} -> {1}")
+    @CsvSource({
+            // K-index 0-2 should return "Quiet"
+            "0, Quiet",
+            "1, Quiet",
+            "2, Quiet",
+            // K-index 3-4 should return "Unsettled"
+            "3, Unsettled",
+            "4, Unsettled",
+            // K-index 5-6 should return "Active"
+            "5, Active",
+            "6, Active",
+            // K-index 7-8 should return "Storm"
+            "7, Storm",
+            "8, Storm",
+            // K-index 9+ should return "Severe Storm"
+            "9, Severe Storm"
+    })
+    void testGetGeomagneticActivity_KIndexMapping(int kIndex, String expectedActivity) {
+        var indices = new SolarIndices(100.0, 10, kIndex, 50, Instant.now(), TEST_SOURCE);
 
-        var indices1 = new SolarIndices(100.0, 10, 1, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Quiet", indices1.getGeomagneticActivity());
-
-        var indices2 = new SolarIndices(100.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Quiet", indices2.getGeomagneticActivity());
-    }
-
-    @Test
-    void testGetGeomagneticActivity_Unsettled() {
-        // K-index 3-4 should return "Unsettled"
-        var indices3 = new SolarIndices(100.0, 10, 3, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Unsettled", indices3.getGeomagneticActivity());
-
-        var indices4 = new SolarIndices(100.0, 10, 4, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Unsettled", indices4.getGeomagneticActivity());
-    }
-
-    @Test
-    void testGetGeomagneticActivity_Active() {
-        // K-index 5-6 should return "Active"
-        var indices5 = new SolarIndices(100.0, 10, 5, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Active", indices5.getGeomagneticActivity());
-
-        var indices6 = new SolarIndices(100.0, 10, 6, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Active", indices6.getGeomagneticActivity());
-    }
-
-    @Test
-    void testGetGeomagneticActivity_Storm() {
-        // K-index 7-8 should return "Storm"
-        var indices7 = new SolarIndices(100.0, 10, 7, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Storm", indices7.getGeomagneticActivity());
-
-        var indices8 = new SolarIndices(100.0, 10, 8, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Storm", indices8.getGeomagneticActivity());
-    }
-
-    @Test
-    void testGetGeomagneticActivity_SevereStorm() {
-        // K-index 9+ should return "Severe Storm"
-        var indices9 = new SolarIndices(100.0, 10, 9, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Severe Storm", indices9.getGeomagneticActivity());
+        assertEquals(expectedActivity, indices.getGeomagneticActivity(),
+                () -> "K-index " + kIndex + " should map to " + expectedActivity);
     }
 
     // ==========================================================================
     // Category 2: getSolarFluxLevel() - SFI to Flux Level Mapping
     // ==========================================================================
 
-    @Test
-    void testGetSolarFluxLevel_VeryLow() {
-        // SFI < 70 should return "Very Low"
-        var indices50 = new SolarIndices(50.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Very Low", indices50.getSolarFluxLevel());
+    @ParameterizedTest(name = "SFI {0} -> {1}")
+    @CsvSource({
+            // SFI < 70 should return "Very Low"
+            "50.0, Very Low",
+            "69.0, Very Low",
+            // SFI 70-99 should return "Low"
+            "70.0, Low",
+            "85.0, Low",
+            "99.0, Low",
+            // SFI 100-149 should return "Moderate"
+            "100.0, Moderate",
+            "125.0, Moderate",
+            "149.0, Moderate",
+            // SFI 150-199 should return "High"
+            "150.0, High",
+            "175.0, High",
+            "199.0, High",
+            // SFI >= 200 should return "Very High"
+            "200.0, Very High",
+            "250.0, Very High",
+            "300.0, Very High"
+    })
+    void testGetSolarFluxLevel_SfiMapping(double sfi, String expectedLevel) {
+        var indices = new SolarIndices(sfi, 10, 2, 50, Instant.now(), TEST_SOURCE);
 
-        var indices69 = new SolarIndices(69.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Very Low", indices69.getSolarFluxLevel());
-    }
-
-    @Test
-    void testGetSolarFluxLevel_Low() {
-        // SFI 70-99 should return "Low"
-        var indices70 = new SolarIndices(70.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Low", indices70.getSolarFluxLevel());
-
-        var indices85 = new SolarIndices(85.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Low", indices85.getSolarFluxLevel());
-
-        var indices99 = new SolarIndices(99.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Low", indices99.getSolarFluxLevel());
-    }
-
-    @Test
-    void testGetSolarFluxLevel_Moderate() {
-        // SFI 100-149 should return "Moderate"
-        var indices100 = new SolarIndices(100.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Moderate", indices100.getSolarFluxLevel());
-
-        var indices125 = new SolarIndices(125.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Moderate", indices125.getSolarFluxLevel());
-
-        var indices149 = new SolarIndices(149.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Moderate", indices149.getSolarFluxLevel());
-    }
-
-    @Test
-    void testGetSolarFluxLevel_High() {
-        // SFI 150-199 should return "High"
-        var indices150 = new SolarIndices(150.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("High", indices150.getSolarFluxLevel());
-
-        var indices175 = new SolarIndices(175.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("High", indices175.getSolarFluxLevel());
-
-        var indices199 = new SolarIndices(199.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("High", indices199.getSolarFluxLevel());
-    }
-
-    @Test
-    void testGetSolarFluxLevel_VeryHigh() {
-        // SFI >= 200 should return "Very High"
-        var indices200 = new SolarIndices(200.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Very High", indices200.getSolarFluxLevel());
-
-        var indices250 = new SolarIndices(250.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Very High", indices250.getSolarFluxLevel());
-
-        var indices300 = new SolarIndices(300.0, 10, 2, 50, Instant.now(), TEST_SOURCE);
-        assertEquals("Very High", indices300.getSolarFluxLevel());
+        assertEquals(expectedLevel, indices.getSolarFluxLevel(),
+                () -> "SFI " + sfi + " should map to " + expectedLevel);
     }
 
     // ==========================================================================


### PR DESCRIPTION
## Summary
- Replace local factory methods with shared fixtures from `mockFactories.ts` and Java fixture classes
- Remove duplicate `formatTimeSince` tests (canonical tests remain in `formatTime.test.ts`)
- Convert repetitive threshold tests to parameterized form using `@ParameterizedTest` (Java) and `it.each()` (TypeScript)
- Add `createMockActivityCardConfig` factory for activity card tests

## Test plan
- [x] All 385 frontend tests pass (`npm run test:run`)
- [x] All Java tests pass (`./gradlew test`)
- [x] Full check passes (`./gradlew check`)
- [x] Delta coverage verified

Closes #242