### PR TITLE
fix(scheduler): defer cache refresh until after transaction commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
       "vite-plugin-checker": "0.12.0",
       "workbox-build": "7.4.0"
     },
-    "hash": "80690df6ee27b029d1b7f3f11e610951704adf8f3e9011261309f1706986c03c"
+    "hash": "44ef3b9810d3a008700b31ed58fef78c2c0e0c61892b6060107e0551536cb7f9"
   },
   "@atakama/cover-diff": {
     "lines": 80,

--- a/src/main/java/io/nextskip/activations/internal/scheduler/PotaRefreshService.java
+++ b/src/main/java/io/nextskip/activations/internal/scheduler/PotaRefreshService.java
@@ -8,9 +8,11 @@ import io.nextskip.activations.persistence.entity.ActivationEntity;
 import io.nextskip.activations.persistence.repository.ActivationRepository;
 import io.nextskip.common.config.CacheConfig;
 import io.nextskip.common.scheduler.AbstractRefreshService;
+import io.nextskip.common.scheduler.CacheRefreshEvent;
 import io.nextskip.common.scheduler.DataRefreshException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
@@ -44,9 +46,11 @@ public class PotaRefreshService extends AbstractRefreshService {
     private int deletedCount;
 
     public PotaRefreshService(
+            ApplicationEventPublisher eventPublisher,
             PotaClient potaClient,
             ActivationRepository repository,
             LoadingCache<String, List<Activation>> activationsCache) {
+        super(eventPublisher);
         this.potaClient = potaClient;
         this.repository = repository;
         this.activationsCache = activationsCache;
@@ -84,8 +88,9 @@ public class PotaRefreshService extends AbstractRefreshService {
     }
 
     @Override
-    protected void refreshCache() {
-        activationsCache.refresh(CacheConfig.CACHE_KEY);
+    protected CacheRefreshEvent createCacheRefreshEvent() {
+        return new CacheRefreshEvent("activations",
+                () -> activationsCache.refresh(CacheConfig.CACHE_KEY));
     }
 
     @Override

--- a/src/main/java/io/nextskip/activations/internal/scheduler/SotaRefreshService.java
+++ b/src/main/java/io/nextskip/activations/internal/scheduler/SotaRefreshService.java
@@ -8,9 +8,11 @@ import io.nextskip.activations.persistence.entity.ActivationEntity;
 import io.nextskip.activations.persistence.repository.ActivationRepository;
 import io.nextskip.common.config.CacheConfig;
 import io.nextskip.common.scheduler.AbstractRefreshService;
+import io.nextskip.common.scheduler.CacheRefreshEvent;
 import io.nextskip.common.scheduler.DataRefreshException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
@@ -44,9 +46,11 @@ public class SotaRefreshService extends AbstractRefreshService {
     private int deletedCount;
 
     public SotaRefreshService(
+            ApplicationEventPublisher eventPublisher,
             SotaClient sotaClient,
             ActivationRepository repository,
             LoadingCache<String, List<Activation>> activationsCache) {
+        super(eventPublisher);
         this.sotaClient = sotaClient;
         this.repository = repository;
         this.activationsCache = activationsCache;
@@ -84,8 +88,9 @@ public class SotaRefreshService extends AbstractRefreshService {
     }
 
     @Override
-    protected void refreshCache() {
-        activationsCache.refresh(CacheConfig.CACHE_KEY);
+    protected CacheRefreshEvent createCacheRefreshEvent() {
+        return new CacheRefreshEvent("activations",
+                () -> activationsCache.refresh(CacheConfig.CACHE_KEY));
     }
 
     @Override

--- a/src/main/java/io/nextskip/common/scheduler/CacheRefreshEvent.java
+++ b/src/main/java/io/nextskip/common/scheduler/CacheRefreshEvent.java
@@ -1,0 +1,21 @@
+package io.nextskip.common.scheduler;
+
+/**
+ * Event published after data refresh to trigger cache reload.
+ *
+ * <p>This event follows the functional strategy pattern - it carries its own refresh action
+ * as a {@link Runnable}. The listener is completely generic and never needs modification
+ * when new cache types are added.
+ *
+ * <p>Published within a {@code @Transactional} method, this event is handled by
+ * {@link CacheRefreshEventListener} which uses {@code @TransactionalEventListener(phase = AFTER_COMMIT)}
+ * to ensure cache refresh happens after the database transaction commits.
+ *
+ * <p>This solves the race condition where cache refresh triggered within a transaction
+ * would query the database before data was committed.
+ *
+ * @param cacheName descriptive name for logging (e.g., "activations", "solarIndices")
+ * @param refreshAction the cache refresh operation to execute post-commit
+ */
+public record CacheRefreshEvent(String cacheName, Runnable refreshAction) {
+}

--- a/src/main/java/io/nextskip/common/scheduler/CacheRefreshEventListener.java
+++ b/src/main/java/io/nextskip/common/scheduler/CacheRefreshEventListener.java
@@ -1,0 +1,43 @@
+package io.nextskip.common.scheduler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Listener that executes cache refresh actions after database transactions commit.
+ *
+ * <p>This listener uses {@code @TransactionalEventListener(phase = AFTER_COMMIT)} to ensure
+ * cache refresh happens only after the database transaction has successfully committed.
+ * This solves the race condition where async cache refresh could query the database
+ * before uncommitted data was visible.
+ *
+ * <p>The listener is completely generic - it simply executes the {@link Runnable} provided
+ * by the {@link CacheRefreshEvent}. This follows the Open/Closed Principle: adding new
+ * cache types requires no changes to this listener.
+ */
+@Component
+public class CacheRefreshEventListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CacheRefreshEventListener.class);
+
+    /**
+     * Handles cache refresh events after transaction commit.
+     *
+     * <p>Executes the refresh action encapsulated in the event. This design ensures:
+     * <ul>
+     *   <li>Database data is committed and visible before cache refresh</li>
+     *   <li>Listener is decoupled from specific cache types</li>
+     *   <li>Each refresh service defines its own refresh logic</li>
+     * </ul>
+     *
+     * @param event the cache refresh event containing the refresh action
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onCacheRefresh(CacheRefreshEvent event) {
+        LOG.debug("Refreshing {} cache after transaction commit", event.cacheName());
+        event.refreshAction().run();
+    }
+}

--- a/src/main/java/io/nextskip/contests/internal/scheduler/ContestRefreshService.java
+++ b/src/main/java/io/nextskip/contests/internal/scheduler/ContestRefreshService.java
@@ -3,6 +3,7 @@ package io.nextskip.contests.internal.scheduler;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.nextskip.common.config.CacheConfig;
 import io.nextskip.common.scheduler.AbstractRefreshService;
+import io.nextskip.common.scheduler.CacheRefreshEvent;
 import io.nextskip.common.scheduler.DataRefreshException;
 import io.nextskip.contests.internal.ContestCalendarClient;
 import io.nextskip.contests.internal.dto.ContestICalDto;
@@ -11,6 +12,7 @@ import io.nextskip.contests.persistence.entity.ContestEntity;
 import io.nextskip.contests.persistence.repository.ContestRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
@@ -41,9 +43,11 @@ public class ContestRefreshService extends AbstractRefreshService {
     private int savedCount;
 
     public ContestRefreshService(
+            ApplicationEventPublisher eventPublisher,
             ContestCalendarClient contestClient,
             ContestRepository repository,
             LoadingCache<String, List<Contest>> contestsCache) {
+        super(eventPublisher);
         this.contestClient = contestClient;
         this.repository = repository;
         this.contestsCache = contestsCache;
@@ -77,8 +81,9 @@ public class ContestRefreshService extends AbstractRefreshService {
     }
 
     @Override
-    protected void refreshCache() {
-        contestsCache.refresh(CacheConfig.CACHE_KEY);
+    protected CacheRefreshEvent createCacheRefreshEvent() {
+        return new CacheRefreshEvent("contests",
+                () -> contestsCache.refresh(CacheConfig.CACHE_KEY));
     }
 
     @Override

--- a/src/main/java/io/nextskip/meteors/internal/scheduler/MeteorRefreshService.java
+++ b/src/main/java/io/nextskip/meteors/internal/scheduler/MeteorRefreshService.java
@@ -3,6 +3,7 @@ package io.nextskip.meteors.internal.scheduler;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.nextskip.common.config.CacheConfig;
 import io.nextskip.common.scheduler.AbstractRefreshService;
+import io.nextskip.common.scheduler.CacheRefreshEvent;
 import io.nextskip.common.scheduler.DataRefreshException;
 import io.nextskip.meteors.internal.MeteorShowerDataLoader;
 import io.nextskip.meteors.model.MeteorShower;
@@ -10,6 +11,7 @@ import io.nextskip.meteors.persistence.entity.MeteorShowerEntity;
 import io.nextskip.meteors.persistence.repository.MeteorShowerRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
@@ -40,9 +42,11 @@ public class MeteorRefreshService extends AbstractRefreshService {
     private int savedCount;
 
     public MeteorRefreshService(
+            ApplicationEventPublisher eventPublisher,
             MeteorShowerDataLoader dataLoader,
             MeteorShowerRepository repository,
             LoadingCache<String, List<MeteorShower>> meteorShowersCache) {
+        super(eventPublisher);
         this.dataLoader = dataLoader;
         this.repository = repository;
         this.meteorShowersCache = meteorShowersCache;
@@ -75,8 +79,9 @@ public class MeteorRefreshService extends AbstractRefreshService {
     }
 
     @Override
-    protected void refreshCache() {
-        meteorShowersCache.refresh(CacheConfig.CACHE_KEY);
+    protected CacheRefreshEvent createCacheRefreshEvent() {
+        return new CacheRefreshEvent("meteorShowers",
+                () -> meteorShowersCache.refresh(CacheConfig.CACHE_KEY));
     }
 
     @Override

--- a/src/main/java/io/nextskip/propagation/internal/scheduler/HamQslBandRefreshService.java
+++ b/src/main/java/io/nextskip/propagation/internal/scheduler/HamQslBandRefreshService.java
@@ -3,6 +3,7 @@ package io.nextskip.propagation.internal.scheduler;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.nextskip.common.config.CacheConfig;
 import io.nextskip.common.scheduler.AbstractRefreshService;
+import io.nextskip.common.scheduler.CacheRefreshEvent;
 import io.nextskip.common.scheduler.DataRefreshException;
 import io.nextskip.propagation.internal.HamQslBandClient;
 import io.nextskip.propagation.model.BandCondition;
@@ -10,6 +11,7 @@ import io.nextskip.propagation.persistence.entity.BandConditionEntity;
 import io.nextskip.propagation.persistence.repository.BandConditionRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
@@ -40,9 +42,11 @@ public class HamQslBandRefreshService extends AbstractRefreshService {
     private int savedCount;
 
     public HamQslBandRefreshService(
+            ApplicationEventPublisher eventPublisher,
             HamQslBandClient hamQslBandClient,
             BandConditionRepository repository,
             LoadingCache<String, List<BandCondition>> bandConditionsCache) {
+        super(eventPublisher);
         this.hamQslBandClient = hamQslBandClient;
         this.repository = repository;
         this.bandConditionsCache = bandConditionsCache;
@@ -74,8 +78,9 @@ public class HamQslBandRefreshService extends AbstractRefreshService {
     }
 
     @Override
-    protected void refreshCache() {
-        bandConditionsCache.refresh(CacheConfig.CACHE_KEY);
+    protected CacheRefreshEvent createCacheRefreshEvent() {
+        return new CacheRefreshEvent("bandConditions",
+                () -> bandConditionsCache.refresh(CacheConfig.CACHE_KEY));
     }
 
     @Override

--- a/src/main/java/io/nextskip/propagation/internal/scheduler/NoaaRefreshService.java
+++ b/src/main/java/io/nextskip/propagation/internal/scheduler/NoaaRefreshService.java
@@ -3,6 +3,7 @@ package io.nextskip.propagation.internal.scheduler;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.nextskip.common.config.CacheConfig;
 import io.nextskip.common.scheduler.AbstractRefreshService;
+import io.nextskip.common.scheduler.CacheRefreshEvent;
 import io.nextskip.common.scheduler.DataRefreshException;
 import io.nextskip.propagation.internal.NoaaSwpcClient;
 import io.nextskip.propagation.model.SolarIndices;
@@ -10,6 +11,7 @@ import io.nextskip.propagation.persistence.entity.SolarIndicesEntity;
 import io.nextskip.propagation.persistence.repository.SolarIndicesRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
@@ -38,9 +40,11 @@ public class NoaaRefreshService extends AbstractRefreshService {
     private int sunspotNumber;
 
     public NoaaRefreshService(
+            ApplicationEventPublisher eventPublisher,
             NoaaSwpcClient noaaClient,
             SolarIndicesRepository repository,
             LoadingCache<String, SolarIndices> solarIndicesCache) {
+        super(eventPublisher);
         this.noaaClient = noaaClient;
         this.repository = repository;
         this.solarIndicesCache = solarIndicesCache;
@@ -71,8 +75,9 @@ public class NoaaRefreshService extends AbstractRefreshService {
     }
 
     @Override
-    protected void refreshCache() {
-        solarIndicesCache.refresh(CacheConfig.CACHE_KEY);
+    protected CacheRefreshEvent createCacheRefreshEvent() {
+        return new CacheRefreshEvent("solarIndices",
+                () -> solarIndicesCache.refresh(CacheConfig.CACHE_KEY));
     }
 
     @Override

--- a/src/test/java/io/nextskip/activations/internal/scheduler/PotaRefreshServiceTest.java
+++ b/src/test/java/io/nextskip/activations/internal/scheduler/PotaRefreshServiceTest.java
@@ -17,6 +17,7 @@ import io.nextskip.activations.model.ActivationType;
 import io.nextskip.activations.persistence.entity.ActivationEntity;
 import io.nextskip.activations.persistence.repository.ActivationRepository;
 import io.nextskip.common.config.CacheConfig;
+import io.nextskip.common.scheduler.CacheRefreshEvent;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 /**
  * Unit tests for PotaRefreshService.
@@ -34,6 +36,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class PotaRefreshServiceTest {
 
     private static final String SOURCE_POTA_API = "POTA API";
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @Mock
     private PotaClient potaClient;
@@ -48,7 +53,7 @@ class PotaRefreshServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new PotaRefreshService(potaClient, repository, activationsCache);
+        service = new PotaRefreshService(eventPublisher, potaClient, repository, activationsCache);
     }
 
     @Test
@@ -96,7 +101,7 @@ class PotaRefreshServiceTest {
     }
 
     @Test
-    void testExecuteRefresh_TriggersCacheRefresh() {
+    void testExecuteRefresh_PublishesCacheRefreshEvent() {
         Activation activation = createTestActivation();
         when(potaClient.fetch()).thenReturn(List.of(activation));
         when(repository.findBySourceAndSpotIdIn(eq(SOURCE_POTA_API), anyList()))
@@ -105,6 +110,15 @@ class PotaRefreshServiceTest {
 
         service.executeRefresh();
 
+        // Verify event is published
+        ArgumentCaptor<CacheRefreshEvent> captor = ArgumentCaptor.forClass(CacheRefreshEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+
+        CacheRefreshEvent event = captor.getValue();
+        assertThat(event.cacheName()).isEqualTo("activations");
+
+        // Verify the refresh action calls the cache
+        event.refreshAction().run();
         verify(activationsCache).refresh(CacheConfig.CACHE_KEY);
     }
 

--- a/src/test/java/io/nextskip/common/scheduler/CacheRefreshEventListenerTest.java
+++ b/src/test/java/io/nextskip/common/scheduler/CacheRefreshEventListenerTest.java
@@ -1,0 +1,43 @@
+package io.nextskip.common.scheduler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for CacheRefreshEventListener.
+ */
+@ExtendWith(MockitoExtension.class)
+class CacheRefreshEventListenerTest {
+
+    @InjectMocks
+    private CacheRefreshEventListener listener;
+
+    @Test
+    void testOnCacheRefresh_ExecutesRefreshAction() {
+        // Given: A mock refresh action
+        Runnable mockAction = mock(Runnable.class);
+        CacheRefreshEvent event = new CacheRefreshEvent("testCache", mockAction);
+
+        // When: The event is handled
+        listener.onCacheRefresh(event);
+
+        // Then: The refresh action is executed
+        verify(mockAction).run();
+    }
+
+    @Test
+    void testOnCacheRefresh_HandlesNoOpAction_DoesNotThrow() {
+        // Given: A no-op refresh action (as used when data is skipped)
+        CacheRefreshEvent event = new CacheRefreshEvent("testCache (skipped)", () -> {});
+
+        // When/Then: The event is handled without error
+        assertThatCode(() -> listener.onCacheRefresh(event))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/io/nextskip/propagation/internal/scheduler/NoaaRefreshServiceTest.java
+++ b/src/test/java/io/nextskip/propagation/internal/scheduler/NoaaRefreshServiceTest.java
@@ -2,6 +2,7 @@ package io.nextskip.propagation.internal.scheduler;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.nextskip.common.config.CacheConfig;
+import io.nextskip.common.scheduler.CacheRefreshEvent;
 import io.nextskip.propagation.internal.NoaaSwpcClient;
 import io.nextskip.propagation.model.SolarIndices;
 import io.nextskip.propagation.persistence.entity.SolarIndicesEntity;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.Instant;
 
@@ -29,6 +31,9 @@ import static org.mockito.Mockito.when;
 class NoaaRefreshServiceTest {
 
     @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
     private NoaaSwpcClient noaaClient;
 
     @Mock
@@ -41,7 +46,7 @@ class NoaaRefreshServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new NoaaRefreshService(noaaClient, repository, solarIndicesCache);
+        service = new NoaaRefreshService(eventPublisher, noaaClient, repository, solarIndicesCache);
     }
 
     @Test
@@ -70,12 +75,21 @@ class NoaaRefreshServiceTest {
     }
 
     @Test
-    void testExecuteRefresh_TriggersCacheRefresh() {
+    void testExecuteRefresh_PublishesCacheRefreshEvent() {
         SolarIndices indices = createTestSolarIndices();
         when(noaaClient.fetch()).thenReturn(indices);
 
         service.executeRefresh();
 
+        // Verify event is published
+        ArgumentCaptor<CacheRefreshEvent> captor = ArgumentCaptor.forClass(CacheRefreshEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+
+        CacheRefreshEvent event = captor.getValue();
+        assertThat(event.cacheName()).isEqualTo("solarIndices");
+
+        // Verify the refresh action calls the cache
+        event.refreshAction().run();
         verify(solarIndicesCache).refresh(CacheConfig.CACHE_KEY);
     }
 


### PR DESCRIPTION
## Summary

Fixes race condition where POTA/SOTA activations showed zero after refresh despite logs showing data was saved. The cache was refreshing asynchronously on ForkJoinPool before the `@Transactional` method committed, causing it to load stale data.

**Root cause**: Caffeine's `cache.refresh()` runs async on a separate thread that starts a new DB transaction unable to see uncommitted writes.

**Solution**: Use Spring's `@TransactionalEventListener(phase = AFTER_COMMIT)` with a functional strategy pattern. Each refresh service creates its own `CacheRefreshEvent` carrying a `Runnable` refresh action - OCP-compliant (no changes needed for new services).

## Changes

- Add `CacheRefreshEvent` record with `cacheName` and `refreshAction`
- Add `CacheRefreshEventListener` to execute refresh after commit
- Update `AbstractRefreshService` to publish event instead of direct cache call
- Update all 7 refresh services with new event-based pattern
- Add/update unit tests for event publishing

## Test plan

- [x] All backend tests pass (`./gradlew test`)
- [x] All frontend tests pass (`npm run validate`)
- [x] Quality checks pass (`./gradlew check`)
- [x] Application starts successfully with correct cache loading:
  ```
  POTA refresh complete: 130 activations saved
  Loaded 252 activations from database  ← Cache now loads correctly
  ```
