### PR TITLE
fix(activations): use lastSeenAt for cache loading and cleanup queries

### DIFF
--- a/src/main/java/io/nextskip/activations/internal/scheduler/PotaRefreshService.java
+++ b/src/main/java/io/nextskip/activations/internal/scheduler/PotaRefreshService.java
@@ -78,9 +78,9 @@ public class PotaRefreshService extends AbstractRefreshService {
             repository.saveAll(entities);
             this.savedCount = entities.size();
 
-            // Cleanup old POTA data (source-filtered to avoid race condition with SOTA refresh)
+            // Cleanup POTA data not seen in API for 2+ hours (source-filtered to avoid race condition)
             Instant cutoff = Instant.now().minus(DATA_RETENTION);
-            this.deletedCount = repository.deleteBySourceAndSpottedAtBefore("POTA API", cutoff);
+            this.deletedCount = repository.deleteBySourceAndLastSeenAtBefore("POTA API", cutoff);
 
         } catch (DataAccessException e) {
             throw new DataRefreshException("Database error during POTA refresh", e);

--- a/src/main/java/io/nextskip/activations/internal/scheduler/SotaRefreshService.java
+++ b/src/main/java/io/nextskip/activations/internal/scheduler/SotaRefreshService.java
@@ -78,9 +78,9 @@ public class SotaRefreshService extends AbstractRefreshService {
             repository.saveAll(entities);
             this.savedCount = entities.size();
 
-            // Cleanup old SOTA data (source-filtered to avoid race condition with POTA refresh)
+            // Cleanup SOTA data not seen in API for 2+ hours (source-filtered to avoid race condition)
             Instant cutoff = Instant.now().minus(DATA_RETENTION);
-            this.deletedCount = repository.deleteBySourceAndSpottedAtBefore("SOTA API", cutoff);
+            this.deletedCount = repository.deleteBySourceAndLastSeenAtBefore("SOTA API", cutoff);
 
         } catch (DataAccessException e) {
             throw new DataRefreshException("Database error during SOTA refresh", e);

--- a/src/main/java/io/nextskip/activations/persistence/repository/ActivationRepository.java
+++ b/src/main/java/io/nextskip/activations/persistence/repository/ActivationRepository.java
@@ -33,6 +33,18 @@ public interface ActivationRepository extends JpaRepository<ActivationEntity, Lo
     List<ActivationEntity> findBySpottedAtAfterOrderBySpottedAtDesc(Instant spottedAt);
 
     /**
+     * Find all activations last seen after a given timestamp.
+     *
+     * <p>Use this method instead of {@link #findBySpottedAtAfterOrderBySpottedAtDesc(Instant)}
+     * when you need activations that are still appearing in API responses, regardless of
+     * their original spot time.
+     *
+     * @param lastSeenAt the timestamp to filter from
+     * @return list of recently observed activations ordered by last seen time descending
+     */
+    List<ActivationEntity> findByLastSeenAtAfterOrderByLastSeenAtDesc(Instant lastSeenAt);
+
+    /**
      * Find all activations of a specific type spotted after a given timestamp.
      *
      * @param type the activation type (POTA or SOTA)
@@ -97,4 +109,16 @@ public interface ActivationRepository extends JpaRepository<ActivationEntity, Lo
      * @return number of deleted records
      */
     int deleteBySourceAndSpottedAtBefore(String source, Instant spottedAt);
+
+    /**
+     * Delete activations from a specific source not seen since a given timestamp.
+     *
+     * <p>Use this method to clean up activations that are no longer appearing in
+     * API responses, regardless of their original spot time.
+     *
+     * @param source the data source identifier (e.g., "POTA API", "SOTA API")
+     * @param lastSeenAt the cutoff timestamp
+     * @return number of deleted records
+     */
+    int deleteBySourceAndLastSeenAtBefore(String source, Instant lastSeenAt);
 }

--- a/src/main/java/io/nextskip/common/config/CacheConfig.java
+++ b/src/main/java/io/nextskip/common/config/CacheConfig.java
@@ -100,7 +100,7 @@ public class CacheConfig {
         LOG.debug("Loading activations from database");
         Instant cutoff = Instant.now(clock).minus(ACTIVATIONS_RETENTION);
         List<Activation> activations = repository
-                .findBySpottedAtAfterOrderBySpottedAtDesc(cutoff)
+                .findByLastSeenAtAfterOrderByLastSeenAtDesc(cutoff)
                 .stream()
                 .map(ActivationEntity::toDomain)
                 .toList();

--- a/src/test/java/io/nextskip/activations/internal/scheduler/PotaRefreshServiceTest.java
+++ b/src/test/java/io/nextskip/activations/internal/scheduler/PotaRefreshServiceTest.java
@@ -62,7 +62,7 @@ class PotaRefreshServiceTest {
         when(potaClient.fetch()).thenReturn(List.of(activation));
         when(repository.findBySourceAndSpotIdIn(eq(SOURCE_POTA_API), anyList()))
                 .thenReturn(Collections.emptyList());
-        when(repository.deleteBySourceAndSpottedAtBefore(eq(SOURCE_POTA_API), any())).thenReturn(0);
+        when(repository.deleteBySourceAndLastSeenAtBefore(eq(SOURCE_POTA_API), any())).thenReturn(0);
 
         service.executeRefresh();
 
@@ -75,7 +75,7 @@ class PotaRefreshServiceTest {
         when(potaClient.fetch()).thenReturn(List.of(activation));
         when(repository.findBySourceAndSpotIdIn(eq(SOURCE_POTA_API), anyList()))
                 .thenReturn(Collections.emptyList());
-        when(repository.deleteBySourceAndSpottedAtBefore(eq(SOURCE_POTA_API), any())).thenReturn(0);
+        when(repository.deleteBySourceAndLastSeenAtBefore(eq(SOURCE_POTA_API), any())).thenReturn(0);
 
         service.executeRefresh();
 
@@ -93,11 +93,11 @@ class PotaRefreshServiceTest {
         when(potaClient.fetch()).thenReturn(List.of(activation));
         when(repository.findBySourceAndSpotIdIn(eq(SOURCE_POTA_API), anyList()))
                 .thenReturn(Collections.emptyList());
-        when(repository.deleteBySourceAndSpottedAtBefore(eq(SOURCE_POTA_API), any())).thenReturn(5);
+        when(repository.deleteBySourceAndLastSeenAtBefore(eq(SOURCE_POTA_API), any())).thenReturn(5);
 
         service.executeRefresh();
 
-        verify(repository).deleteBySourceAndSpottedAtBefore(eq(SOURCE_POTA_API), any());
+        verify(repository).deleteBySourceAndLastSeenAtBefore(eq(SOURCE_POTA_API), any());
     }
 
     @Test
@@ -106,7 +106,7 @@ class PotaRefreshServiceTest {
         when(potaClient.fetch()).thenReturn(List.of(activation));
         when(repository.findBySourceAndSpotIdIn(eq(SOURCE_POTA_API), anyList()))
                 .thenReturn(Collections.emptyList());
-        when(repository.deleteBySourceAndSpottedAtBefore(eq(SOURCE_POTA_API), any())).thenReturn(0);
+        when(repository.deleteBySourceAndLastSeenAtBefore(eq(SOURCE_POTA_API), any())).thenReturn(0);
 
         service.executeRefresh();
 
@@ -135,7 +135,7 @@ class PotaRefreshServiceTest {
     @Test
     void testExecuteRefresh_EmptyList_SavesNothing() {
         when(potaClient.fetch()).thenReturn(Collections.emptyList());
-        when(repository.deleteBySourceAndSpottedAtBefore(eq(SOURCE_POTA_API), any())).thenReturn(0);
+        when(repository.deleteBySourceAndLastSeenAtBefore(eq(SOURCE_POTA_API), any())).thenReturn(0);
 
         service.executeRefresh();
 
@@ -156,7 +156,7 @@ class PotaRefreshServiceTest {
         when(potaClient.fetch()).thenReturn(List.of(activation));
         when(repository.findBySourceAndSpotIdIn(eq(SOURCE_POTA_API), anyList()))
                 .thenReturn(List.of(existingEntity));
-        when(repository.deleteBySourceAndSpottedAtBefore(eq(SOURCE_POTA_API), any())).thenReturn(0);
+        when(repository.deleteBySourceAndLastSeenAtBefore(eq(SOURCE_POTA_API), any())).thenReturn(0);
 
         // When: Executing the refresh
         service.executeRefresh();

--- a/src/test/java/io/nextskip/activations/internal/scheduler/SotaRefreshServiceTest.java
+++ b/src/test/java/io/nextskip/activations/internal/scheduler/SotaRefreshServiceTest.java
@@ -62,7 +62,7 @@ class SotaRefreshServiceTest {
         when(sotaClient.fetch()).thenReturn(List.of(activation));
         when(repository.findBySourceAndSpotIdIn(eq(SOURCE_SOTA_API), anyList()))
                 .thenReturn(Collections.emptyList());
-        when(repository.deleteBySourceAndSpottedAtBefore(eq(SOURCE_SOTA_API), any())).thenReturn(0);
+        when(repository.deleteBySourceAndLastSeenAtBefore(eq(SOURCE_SOTA_API), any())).thenReturn(0);
 
         service.executeRefresh();
 
@@ -75,7 +75,7 @@ class SotaRefreshServiceTest {
         when(sotaClient.fetch()).thenReturn(List.of(activation));
         when(repository.findBySourceAndSpotIdIn(eq(SOURCE_SOTA_API), anyList()))
                 .thenReturn(Collections.emptyList());
-        when(repository.deleteBySourceAndSpottedAtBefore(eq(SOURCE_SOTA_API), any())).thenReturn(0);
+        when(repository.deleteBySourceAndLastSeenAtBefore(eq(SOURCE_SOTA_API), any())).thenReturn(0);
 
         service.executeRefresh();
 
@@ -93,11 +93,11 @@ class SotaRefreshServiceTest {
         when(sotaClient.fetch()).thenReturn(List.of(activation));
         when(repository.findBySourceAndSpotIdIn(eq(SOURCE_SOTA_API), anyList()))
                 .thenReturn(Collections.emptyList());
-        when(repository.deleteBySourceAndSpottedAtBefore(eq(SOURCE_SOTA_API), any())).thenReturn(3);
+        when(repository.deleteBySourceAndLastSeenAtBefore(eq(SOURCE_SOTA_API), any())).thenReturn(3);
 
         service.executeRefresh();
 
-        verify(repository).deleteBySourceAndSpottedAtBefore(eq(SOURCE_SOTA_API), any());
+        verify(repository).deleteBySourceAndLastSeenAtBefore(eq(SOURCE_SOTA_API), any());
     }
 
     @Test
@@ -106,7 +106,7 @@ class SotaRefreshServiceTest {
         when(sotaClient.fetch()).thenReturn(List.of(activation));
         when(repository.findBySourceAndSpotIdIn(eq(SOURCE_SOTA_API), anyList()))
                 .thenReturn(Collections.emptyList());
-        when(repository.deleteBySourceAndSpottedAtBefore(eq(SOURCE_SOTA_API), any())).thenReturn(0);
+        when(repository.deleteBySourceAndLastSeenAtBefore(eq(SOURCE_SOTA_API), any())).thenReturn(0);
 
         service.executeRefresh();
 
@@ -135,7 +135,7 @@ class SotaRefreshServiceTest {
     @Test
     void testExecuteRefresh_EmptyList_SavesNothing() {
         when(sotaClient.fetch()).thenReturn(Collections.emptyList());
-        when(repository.deleteBySourceAndSpottedAtBefore(eq(SOURCE_SOTA_API), any())).thenReturn(0);
+        when(repository.deleteBySourceAndLastSeenAtBefore(eq(SOURCE_SOTA_API), any())).thenReturn(0);
 
         service.executeRefresh();
 
@@ -156,7 +156,7 @@ class SotaRefreshServiceTest {
         when(sotaClient.fetch()).thenReturn(List.of(activation));
         when(repository.findBySourceAndSpotIdIn(eq(SOURCE_SOTA_API), anyList()))
                 .thenReturn(List.of(existingEntity));
-        when(repository.deleteBySourceAndSpottedAtBefore(eq(SOURCE_SOTA_API), any())).thenReturn(0);
+        when(repository.deleteBySourceAndLastSeenAtBefore(eq(SOURCE_SOTA_API), any())).thenReturn(0);
 
         // When: Executing the refresh
         service.executeRefresh();

--- a/src/test/java/io/nextskip/common/config/CacheConfigTest.java
+++ b/src/test/java/io/nextskip/common/config/CacheConfigTest.java
@@ -86,7 +86,7 @@ class CacheConfigTest {
     @Test
     void testActivationsCache_LoadsFromRepository() {
         // Given: Repository returns empty list
-        when(activationRepository.findBySpottedAtAfterOrderBySpottedAtDesc(any()))
+        when(activationRepository.findByLastSeenAtAfterOrderByLastSeenAtDesc(any()))
                 .thenReturn(Collections.emptyList());
 
         // When: Create cache and get data
@@ -171,7 +171,7 @@ class CacheConfigTest {
                 new Park("K-1234", "Test Park", "CA", "US", "CM97", 37.5, -122.1)
         );
         ActivationEntity entity = ActivationEntity.fromDomain(activation);
-        when(activationRepository.findBySpottedAtAfterOrderBySpottedAtDesc(any()))
+        when(activationRepository.findByLastSeenAtAfterOrderByLastSeenAtDesc(any()))
                 .thenReturn(List.of(entity));
 
         // When: Call loader method directly
@@ -187,7 +187,7 @@ class CacheConfigTest {
     @Test
     void testLoadActivations_ReturnsEmptyList() {
         // Given: Repository returns empty list
-        when(activationRepository.findBySpottedAtAfterOrderBySpottedAtDesc(any()))
+        when(activationRepository.findByLastSeenAtAfterOrderByLastSeenAtDesc(any()))
                 .thenReturn(Collections.emptyList());
 
         // When: Call loader method directly


### PR DESCRIPTION
## Summary
- Fix cache loading to query by `lastSeenAt` instead of `spottedAt`
- Fix cleanup to delete by `lastSeenAt` instead of `spottedAt`
- Resolves issue where POTA/SOTA cards showed zero stations despite successful saves

## Problem
The `lastSeenAt` feature was incomplete. Cache loading and cleanup queries still used `spottedAt` (original spot time from API), causing activations with old `spottedAt` but fresh `lastSeenAt` to be filtered out.

Logs showed:
```
POTA refresh complete: 28 activations saved, 28 old records deleted
Loaded 0 activations from database  ← Wrong!
```

## Solution
- Added `findByLastSeenAtAfterOrderByLastSeenAtDesc` repository method
- Added `deleteBySourceAndLastSeenAtBefore` repository method
- Updated `CacheConfig.loadActivations()` to use `lastSeenAt` query
- Updated `PotaRefreshService`/`SotaRefreshService` cleanup to use `lastSeenAt`

## Test plan
- [x] All backend tests pass
- [x] All frontend tests pass (391 passing)
- [x] Quality checks pass (Checkstyle, PMD, SpotBugs)
- [x] Application starts successfully
- [x] Verified activations now load correctly from database