### PR TITLE
fix(activations): use spottedAt for scoring/display and fix cache-first bug

### DIFF
--- a/src/main/frontend/components/cards/activations/ActivationsContent.tsx
+++ b/src/main/frontend/components/cards/activations/ActivationsContent.tsx
@@ -57,7 +57,7 @@ function ActivationsContent({ activations, type, emptyMessage }: Props) {
               <div className="activation-details">
                 <span className="frequency">{formatFrequency(activation.frequency)}</span>
                 <span className="mode">{activation.mode || 'Unknown'}</span>
-                <span className="time-since">{formatTimeSince(activation.lastSeenAt)}</span>
+                <span className="time-since">{formatTimeSince(activation.spottedAt)}</span>
               </div>
               {(activation.location as ActivationLocationExt)?.name ? (
                 <div className={locationClass}>

--- a/src/main/java/io/nextskip/activations/model/Activation.java
+++ b/src/main/java/io/nextskip/activations/model/Activation.java
@@ -7,13 +7,13 @@ import java.time.Duration;
 /**
  * Represents an individual amateur radio activation event (POTA or SOTA).
  *
- * <p>Implements scoring based on recency - activations recently seen in API refreshes
+ * <p>Implements scoring based on recency - activations with recent spot times
  * score higher as they're more likely to be currently active.</p>
  *
  * <p>Follows SOLID principles:
  * <ul>
- *   <li><b>SRP</b>: {@code spottedAt} = original spot time (informational),
- *       {@code lastSeenAt} = freshness tracking (scoring)</li>
+ *   <li><b>SRP</b>: {@code spottedAt} = when someone last reported hearing the station (scoring),
+ *       {@code lastSeenAt} = when our API client observed the spot (cache management)</li>
  *   <li><b>DIP</b>: Scoring methods accept {@code Instant asOf} parameter
  *       for deterministic testing (no dependency on {@code Instant.now()})</li>
  * </ul>
@@ -25,8 +25,8 @@ import java.time.Duration;
  * @param type Type of activation (POTA or SOTA)
  * @param frequency Operating frequency in kHz
  * @param mode Operating mode (e.g., "SSB", "CW", "FT8")
- * @param spottedAt Timestamp when the activation was originally spotted (informational)
- * @param lastSeenAt Timestamp when the activation was last observed in an API refresh
+ * @param spottedAt Timestamp when someone last reported hearing the station (used for scoring)
+ * @param lastSeenAt Timestamp when the activation was last observed in an API refresh (cache only)
  * @param qsoCount Number of QSOs completed (if available)
  * @param source Data source identifier
  * @param location Location being activated (Park for POTA, Summit for SOTA)
@@ -51,12 +51,12 @@ public record Activation(
     private static final long STALE_THRESHOLD_MINUTES = 60;
 
     /**
-     * An activation is favorable if it was last seen within the past 15 minutes.
+     * An activation is favorable if it was spotted within the past 15 minutes.
      *
      * <p>Uses the current time as reference. For deterministic testing, use
      * {@link #isFavorable(Instant)} with an explicit reference time.</p>
      *
-     * @return true if the activation was recently seen and likely still active
+     * @return true if the activation was recently spotted and likely still active
      */
     @Override
     public boolean isFavorable() {
@@ -64,24 +64,24 @@ public record Activation(
     }
 
     /**
-     * An activation is favorable if it was last seen within the past 15 minutes.
+     * An activation is favorable if it was spotted within the past 15 minutes.
      *
      * <p>This method follows the Dependency Inversion Principle by accepting an
      * explicit reference time, enabling deterministic unit tests.</p>
      *
      * @param asOf the reference time to calculate recency from
-     * @return true if the activation was recently seen and likely still active
+     * @return true if the activation was recently spotted and likely still active
      */
     public boolean isFavorable(Instant asOf) {
-        if (lastSeenAt == null) {
+        if (spottedAt == null) {
             return false;
         }
-        Duration age = Duration.between(lastSeenAt, asOf);
+        Duration age = Duration.between(spottedAt, asOf);
         return age.toMinutes() <= FRESH_THRESHOLD_MINUTES;
     }
 
     /**
-     * Calculate score based on how recently the activation was last seen.
+     * Calculate score based on how recently the activation was spotted.
      *
      * <p>Uses the current time as reference. For deterministic testing, use
      * {@link #getScore(Instant)} with an explicit reference time.</p>
@@ -94,12 +94,12 @@ public record Activation(
     }
 
     /**
-     * Calculate score based on how recently the activation was last seen.
+     * Calculate score based on how recently the activation was spotted.
      *
      * <p>This method follows the Dependency Inversion Principle by accepting an
      * explicit reference time, enabling deterministic unit tests.</p>
      *
-     * <p>Scoring algorithm (based on time since last seen):
+     * <p>Scoring algorithm (based on time since spotted):
      * <ul>
      *   <li>0-5 minutes: 100 points (very fresh)</li>
      *   <li>5-15 minutes: 80-100 points (fresh, linear decay)</li>
@@ -108,18 +108,18 @@ public record Activation(
      *   <li>60+ minutes: 0 points (expired)</li>
      * </ul>
      *
-     * <p>Scoring is based solely on {@code lastSeenAt}. If {@code lastSeenAt}
+     * <p>Scoring is based solely on {@code spottedAt}. If {@code spottedAt}
      * is null (which should not happen in production), returns 0.</p>
      *
      * @param asOf the reference time to calculate recency from
      * @return score from 0-100 based on recency
      */
     public int getScore(Instant asOf) {
-        if (lastSeenAt == null) {
+        if (spottedAt == null) {
             return 0;
         }
 
-        Duration age = Duration.between(lastSeenAt, asOf);
+        Duration age = Duration.between(spottedAt, asOf);
         long minutes = age.toMinutes();
 
         if (minutes < 0) {

--- a/src/main/java/io/nextskip/common/client/AbstractExternalDataClient.java
+++ b/src/main/java/io/nextskip/common/client/AbstractExternalDataClient.java
@@ -180,15 +180,8 @@ public abstract class AbstractExternalDataClient<T>
     @Override
     @SuppressWarnings("unchecked")
     public final T fetch() {
-        // Check cache first (like @Cacheable behavior)
-        Cache cache = cacheManager.getCache(getCacheName());
-        if (cache != null) {
-            Cache.ValueWrapper cached = cache.get(getCacheKey());
-            if (cached != null && cached.get() != null) {
-                log.debug("Returning cached data for {}", getSourceName());
-                return (T) cached.get();
-            }
-        }
+        // Always call the API - cache is only used as fallback on failure
+        // (see getCachedDataWithFallback in the catch block below)
 
         Supplier<T> decoratedFetch = () -> {
             try {

--- a/src/main/java/io/nextskip/common/config/CacheConfig.java
+++ b/src/main/java/io/nextskip/common/config/CacheConfig.java
@@ -100,7 +100,7 @@ public class CacheConfig {
         LOG.debug("Loading activations from database");
         Instant cutoff = Instant.now(clock).minus(ACTIVATIONS_RETENTION);
         List<Activation> activations = repository
-                .findByLastSeenAtAfterOrderByLastSeenAtDesc(cutoff)
+                .findBySpottedAtAfterOrderBySpottedAtDesc(cutoff)
                 .stream()
                 .map(ActivationEntity::toDomain)
                 .toList();

--- a/src/test/frontend/components/cards/activations/PotaActivationsContent.test.tsx
+++ b/src/test/frontend/components/cards/activations/PotaActivationsContent.test.tsx
@@ -87,7 +87,7 @@ describe('PotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const fiveMinutesAgo = new Date('2025-01-15T11:55:00Z');
-    const activations = [createMockPotaActivation({ lastSeenAt: fiveMinutesAgo.toISOString() })];
+    const activations = [createMockPotaActivation({ spottedAt: fiveMinutesAgo.toISOString() })];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -139,7 +139,7 @@ describe('PotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const thirtySecondsAgo = new Date('2025-01-15T11:59:30Z');
-    const activations = [createMockPotaActivation({ lastSeenAt: thirtySecondsAgo.toISOString() })];
+    const activations = [createMockPotaActivation({ spottedAt: thirtySecondsAgo.toISOString() })];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -153,7 +153,7 @@ describe('PotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const oneMinuteAgo = new Date('2025-01-15T11:59:00Z');
-    const activations = [createMockPotaActivation({ lastSeenAt: oneMinuteAgo.toISOString() })];
+    const activations = [createMockPotaActivation({ spottedAt: oneMinuteAgo.toISOString() })];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -167,7 +167,7 @@ describe('PotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const twoHoursAgo = new Date('2025-01-15T10:00:00Z');
-    const activations = [createMockPotaActivation({ lastSeenAt: twoHoursAgo.toISOString() })];
+    const activations = [createMockPotaActivation({ spottedAt: twoHoursAgo.toISOString() })];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -181,7 +181,7 @@ describe('PotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const oneHourAgo = new Date('2025-01-15T11:00:00Z');
-    const activations = [createMockPotaActivation({ lastSeenAt: oneHourAgo.toISOString() })];
+    const activations = [createMockPotaActivation({ spottedAt: oneHourAgo.toISOString() })];
 
     render(<PotaActivationsContent activations={activations} />);
 
@@ -191,7 +191,7 @@ describe('PotaActivationsContent', () => {
   });
 
   it('should display "Unknown" for null timestamp', () => {
-    const activations = [createMockPotaActivation({ lastSeenAt: undefined })];
+    const activations = [createMockPotaActivation({ spottedAt: undefined })];
 
     render(<PotaActivationsContent activations={activations} />);
 

--- a/src/test/frontend/components/cards/activations/SotaActivationsContent.test.tsx
+++ b/src/test/frontend/components/cards/activations/SotaActivationsContent.test.tsx
@@ -94,7 +94,7 @@ describe('SotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const tenMinutesAgo = new Date('2025-01-15T11:50:00Z');
-    const activations = [createMockActivation({ lastSeenAt: tenMinutesAgo.toISOString() })];
+    const activations = [createMockActivation({ spottedAt: tenMinutesAgo.toISOString() })];
 
     render(<SotaActivationsContent activations={activations} />);
 
@@ -146,7 +146,7 @@ describe('SotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const fortyFiveSecondsAgo = new Date('2025-01-15T11:59:15Z');
-    const activations = [createMockActivation({ lastSeenAt: fortyFiveSecondsAgo.toISOString() })];
+    const activations = [createMockActivation({ spottedAt: fortyFiveSecondsAgo.toISOString() })];
 
     render(<SotaActivationsContent activations={activations} />);
 
@@ -160,7 +160,7 @@ describe('SotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const oneMinuteAgo = new Date('2025-01-15T11:59:00Z');
-    const activations = [createMockActivation({ lastSeenAt: oneMinuteAgo.toISOString() })];
+    const activations = [createMockActivation({ spottedAt: oneMinuteAgo.toISOString() })];
 
     render(<SotaActivationsContent activations={activations} />);
 
@@ -174,7 +174,7 @@ describe('SotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const threeHoursAgo = new Date('2025-01-15T09:00:00Z');
-    const activations = [createMockActivation({ lastSeenAt: threeHoursAgo.toISOString() })];
+    const activations = [createMockActivation({ spottedAt: threeHoursAgo.toISOString() })];
 
     render(<SotaActivationsContent activations={activations} />);
 
@@ -188,7 +188,7 @@ describe('SotaActivationsContent', () => {
     vi.setSystemTime(now);
 
     const oneHourAgo = new Date('2025-01-15T11:00:00Z');
-    const activations = [createMockActivation({ lastSeenAt: oneHourAgo.toISOString() })];
+    const activations = [createMockActivation({ spottedAt: oneHourAgo.toISOString() })];
 
     render(<SotaActivationsContent activations={activations} />);
 
@@ -198,7 +198,7 @@ describe('SotaActivationsContent', () => {
   });
 
   it('should display "Unknown" for null timestamp', () => {
-    const activations = [createMockActivation({ lastSeenAt: undefined })];
+    const activations = [createMockActivation({ spottedAt: undefined })];
 
     render(<SotaActivationsContent activations={activations} />);
 

--- a/src/test/java/io/nextskip/common/config/CacheConfigTest.java
+++ b/src/test/java/io/nextskip/common/config/CacheConfigTest.java
@@ -86,7 +86,7 @@ class CacheConfigTest {
     @Test
     void testActivationsCache_LoadsFromRepository() {
         // Given: Repository returns empty list
-        when(activationRepository.findByLastSeenAtAfterOrderByLastSeenAtDesc(any()))
+        when(activationRepository.findBySpottedAtAfterOrderBySpottedAtDesc(any()))
                 .thenReturn(Collections.emptyList());
 
         // When: Create cache and get data
@@ -171,7 +171,7 @@ class CacheConfigTest {
                 new Park("K-1234", "Test Park", "CA", "US", "CM97", 37.5, -122.1)
         );
         ActivationEntity entity = ActivationEntity.fromDomain(activation);
-        when(activationRepository.findByLastSeenAtAfterOrderByLastSeenAtDesc(any()))
+        when(activationRepository.findBySpottedAtAfterOrderBySpottedAtDesc(any()))
                 .thenReturn(List.of(entity));
 
         // When: Call loader method directly
@@ -187,7 +187,7 @@ class CacheConfigTest {
     @Test
     void testLoadActivations_ReturnsEmptyList() {
         // Given: Repository returns empty list
-        when(activationRepository.findByLastSeenAtAfterOrderByLastSeenAtDesc(any()))
+        when(activationRepository.findBySpottedAtAfterOrderBySpottedAtDesc(any()))
                 .thenReturn(Collections.emptyList());
 
         // When: Call loader method directly


### PR DESCRIPTION
## Summary

- Use `spottedAt` (API timestamp when someone reported hearing the station) instead of `lastSeenAt` (when we scraped the API) for activation scoring and display
- Fix bug where cache was checked before calling API, causing refreshes to never fetch new data

## Changes

### 1. Use spottedAt for freshness
- **Scoring**: `Activation.isFavorable()` and `getScore()` now use `spottedAt`
- **Display**: Frontend shows "X min ago" based on `spottedAt`
- **Cache loading**: Filter and sort by `spottedAt` in `CacheConfig`

### 2. Fix cache-first bug
- `AbstractExternalDataClient.fetch()` was returning cached data immediately without calling API
- Now API is always called; cache only used as fallback on failure

## Test plan

- [x] Backend tests pass (`./gradlew test`)
- [x] Frontend tests pass (`npm run test:run`)
- [x] Manual verification: timestamps now show accurate "last heard" times

## Related

- Ref: #262 (follow-up to remove now-redundant client-level caching)