### PR TITLE
fix(scheduler): add @Qualifier to resolve RecurringTask bean injection

### DIFF
--- a/src/main/java/io/nextskip/activations/internal/scheduler/PotaRefreshTask.java
+++ b/src/main/java/io/nextskip/activations/internal/scheduler/PotaRefreshTask.java
@@ -7,6 +7,7 @@ import io.nextskip.activations.model.ActivationType;
 import io.nextskip.activations.persistence.repository.ActivationRepository;
 import io.nextskip.common.scheduler.RefreshTaskCoordinator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -51,8 +52,9 @@ public class PotaRefreshTask implements RefreshTaskCoordinator {
      * @param recurringTask the created recurring task bean
      */
     @Autowired
-    public void setRecurringTask(@Lazy RecurringTask<Void> potaRecurringTask) {
-        this.recurringTask = potaRecurringTask;
+    public void setRecurringTask(
+            @Lazy @Qualifier("potaRecurringTask") RecurringTask<Void> task) {
+        this.recurringTask = task;
     }
 
     /**

--- a/src/main/java/io/nextskip/activations/internal/scheduler/SotaRefreshTask.java
+++ b/src/main/java/io/nextskip/activations/internal/scheduler/SotaRefreshTask.java
@@ -7,6 +7,7 @@ import io.nextskip.activations.model.ActivationType;
 import io.nextskip.activations.persistence.repository.ActivationRepository;
 import io.nextskip.common.scheduler.RefreshTaskCoordinator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -51,8 +52,9 @@ public class SotaRefreshTask implements RefreshTaskCoordinator {
      * @param recurringTask the created recurring task bean
      */
     @Autowired
-    public void setRecurringTask(@Lazy RecurringTask<Void> sotaRecurringTask) {
-        this.recurringTask = sotaRecurringTask;
+    public void setRecurringTask(
+            @Lazy @Qualifier("sotaRecurringTask") RecurringTask<Void> task) {
+        this.recurringTask = task;
     }
 
     /**

--- a/src/main/java/io/nextskip/contests/internal/scheduler/ContestRefreshTask.java
+++ b/src/main/java/io/nextskip/contests/internal/scheduler/ContestRefreshTask.java
@@ -6,6 +6,7 @@ import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import io.nextskip.common.scheduler.RefreshTaskCoordinator;
 import io.nextskip.contests.persistence.repository.ContestRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -49,8 +50,9 @@ public class ContestRefreshTask implements RefreshTaskCoordinator {
      * @param recurringTask the created recurring task bean
      */
     @Autowired
-    public void setRecurringTask(@Lazy RecurringTask<Void> contestRecurringTask) {
-        this.recurringTask = contestRecurringTask;
+    public void setRecurringTask(
+            @Lazy @Qualifier("contestRecurringTask") RecurringTask<Void> task) {
+        this.recurringTask = task;
     }
 
     /**

--- a/src/main/java/io/nextskip/meteors/internal/scheduler/MeteorRefreshTask.java
+++ b/src/main/java/io/nextskip/meteors/internal/scheduler/MeteorRefreshTask.java
@@ -6,6 +6,7 @@ import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import io.nextskip.common.scheduler.RefreshTaskCoordinator;
 import io.nextskip.meteors.persistence.repository.MeteorShowerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -50,8 +51,9 @@ public class MeteorRefreshTask implements RefreshTaskCoordinator {
      * @param recurringTask the created recurring task bean
      */
     @Autowired
-    public void setRecurringTask(@Lazy RecurringTask<Void> meteorRecurringTask) {
-        this.recurringTask = meteorRecurringTask;
+    public void setRecurringTask(
+            @Lazy @Qualifier("meteorRecurringTask") RecurringTask<Void> task) {
+        this.recurringTask = task;
     }
 
     /**

--- a/src/main/java/io/nextskip/propagation/internal/scheduler/HamQslBandRefreshTask.java
+++ b/src/main/java/io/nextskip/propagation/internal/scheduler/HamQslBandRefreshTask.java
@@ -6,6 +6,7 @@ import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import io.nextskip.common.scheduler.RefreshTaskCoordinator;
 import io.nextskip.propagation.persistence.repository.BandConditionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -51,8 +52,9 @@ public class HamQslBandRefreshTask implements RefreshTaskCoordinator {
      * @param recurringTask the created recurring task bean
      */
     @Autowired
-    public void setRecurringTask(@Lazy RecurringTask<Void> hamQslBandRecurringTask) {
-        this.recurringTask = hamQslBandRecurringTask;
+    public void setRecurringTask(
+            @Lazy @Qualifier("hamQslBandRecurringTask") RecurringTask<Void> task) {
+        this.recurringTask = task;
     }
 
     /**

--- a/src/main/java/io/nextskip/propagation/internal/scheduler/HamQslSolarRefreshTask.java
+++ b/src/main/java/io/nextskip/propagation/internal/scheduler/HamQslSolarRefreshTask.java
@@ -6,6 +6,7 @@ import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import io.nextskip.common.scheduler.RefreshTaskCoordinator;
 import io.nextskip.propagation.persistence.repository.SolarIndicesRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -51,8 +52,9 @@ public class HamQslSolarRefreshTask implements RefreshTaskCoordinator {
      * @param recurringTask the created recurring task bean
      */
     @Autowired
-    public void setRecurringTask(@Lazy RecurringTask<Void> hamQslSolarRecurringTask) {
-        this.recurringTask = hamQslSolarRecurringTask;
+    public void setRecurringTask(
+            @Lazy @Qualifier("hamQslSolarRecurringTask") RecurringTask<Void> task) {
+        this.recurringTask = task;
     }
 
     /**

--- a/src/main/java/io/nextskip/propagation/internal/scheduler/NoaaRefreshTask.java
+++ b/src/main/java/io/nextskip/propagation/internal/scheduler/NoaaRefreshTask.java
@@ -6,6 +6,7 @@ import com.github.kagkarlsson.scheduler.task.schedule.FixedDelay;
 import io.nextskip.common.scheduler.RefreshTaskCoordinator;
 import io.nextskip.propagation.persistence.repository.SolarIndicesRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -54,8 +55,9 @@ public class NoaaRefreshTask implements RefreshTaskCoordinator {
      * @param recurringTask the created recurring task bean
      */
     @Autowired
-    public void setRecurringTask(@Lazy RecurringTask<Void> noaaRecurringTask) {
-        this.recurringTask = noaaRecurringTask;
+    public void setRecurringTask(
+            @Lazy @Qualifier("noaaRecurringTask") RecurringTask<Void> task) {
+        this.recurringTask = task;
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds `@Qualifier` annotation to all 7 `RefreshTaskCoordinator` implementations to resolve Spring bean injection failure.

**Problem**: Spring was unable to resolve `RecurringTask` beans by parameter name during setter injection. When attempting to reschedule tasks, Spring found 7 other `RecurringTask` beans but not the one from the current class.

**Solution**: Added explicit `@Qualifier` annotations to specify the correct bean name for each setter:
- `PotaRefreshTask` → `@Qualifier("potaRecurringTask")`
- `SotaRefreshTask` → `@Qualifier("sotaRecurringTask")`
- `NoaaRefreshTask` → `@Qualifier("noaaRecurringTask")`
- `HamQslBandRefreshTask` → `@Qualifier("hamQslBandRecurringTask")`
- `HamQslSolarRefreshTask` → `@Qualifier("hamQslSolarRecurringTask")`
- `ContestRefreshTask` → `@Qualifier("contestRecurringTask")`
- `MeteorRefreshTask` → `@Qualifier("meteorRecurringTask")`

Fixes #270

## Test Plan

- [x] `./gradlew build` passes
- [x] All existing unit tests pass
- [ ] Verify startup data refresh works on cold start