### PR TITLE
feat(common): add SWL callsign support and remove LAST_CHAR_NOT_LETTER validation

### DIFF
--- a/src/test/java/io/nextskip/common/model/CallsignTest.java
+++ b/src/test/java/io/nextskip/common/model/CallsignTest.java
@@ -479,6 +479,69 @@ class CallsignTest {
     }
 
     // ===========================================
+    // SWL (Shortwave Listener) tests
+    // ===========================================
+
+    @Test
+    void testIsSwl_NetherlandsSwl_ReturnsTrue() {
+        Callsign callsign = new Callsign("NL9222");
+
+        assertThat(callsign.isSwl()).isTrue();
+    }
+
+    @Test
+    void testIsSwl_UkRsgbSwl_ReturnsTrue() {
+        Callsign callsign = new Callsign("RS123456");
+
+        assertThat(callsign.isSwl()).isTrue();
+    }
+
+    @Test
+    void testIsSwl_GermanySwl_ReturnsTrue() {
+        Callsign callsign = new Callsign("DE12345");
+
+        assertThat(callsign.isSwl()).isTrue();
+    }
+
+    @Test
+    void testIsSwl_StandardCallsign_ReturnsFalse() {
+        Callsign callsign = new Callsign("W1AW");
+
+        assertThat(callsign.isSwl()).isFalse();
+    }
+
+    @Test
+    void testIsSwl_TooFewDigits_ReturnsFalse() {
+        // SWL requires 3-6 digits
+        Callsign callsign = new Callsign("NL12");
+
+        assertThat(callsign.isSwl()).isFalse();
+    }
+
+    @Test
+    void testIsSwl_TooManyDigits_ReturnsFalse() {
+        // SWL requires 3-6 digits
+        Callsign callsign = new Callsign("NL1234567");
+
+        assertThat(callsign.isSwl()).isFalse();
+    }
+
+    @Test
+    void testIsSwl_SingleLetterPrefix_ReturnsFalse() {
+        // SWL requires 2-3 letter prefix
+        Callsign callsign = new Callsign("N12345");
+
+        assertThat(callsign.isSwl()).isFalse();
+    }
+
+    @Test
+    void testIsSwl_CaseInsensitive_ReturnsTrue() {
+        Callsign callsign = new Callsign("nl9222");
+
+        assertThat(callsign.isSwl()).isTrue();
+    }
+
+    // ===========================================
     // Validation tests
     // ===========================================
 
@@ -518,11 +581,12 @@ class CallsignTest {
     }
 
     @Test
-    void testIsValid_TwoCharEndsInDigit_ReturnsFalse() {
+    void testIsValid_TwoCharEndsInDigit_ReturnsTrue() {
         Callsign callsign = new Callsign("W1");
 
-        // Fails because last char is not a letter (ITU guideline)
-        assertThat(callsign.isValid()).isFalse();
+        // Two-character callsigns ending in digit are now valid
+        // (LAST_CHAR_NOT_LETTER check removed to support SWL callsigns)
+        assertThat(callsign.isValid()).isTrue();
     }
 
     @Test
@@ -674,23 +738,23 @@ class CallsignTest {
     }
 
     @Test
-    void testValidate_LastCharDigit_ReturnsLastCharNotLetterFailure() {
+    void testValidate_LastCharDigit_ReturnsValid() {
+        // Callsigns ending in digits are now valid (supports SWL callsigns)
         Callsign callsign = new Callsign("W1AB1");
 
         Callsign.ValidationResult result = callsign.validate();
 
-        assertThat(result.isValid()).isFalse();
-        assertThat(result.failure()).isEqualTo(Callsign.ValidationFailure.LAST_CHAR_NOT_LETTER);
+        assertThat(result.isValid()).isTrue();
     }
 
     @Test
-    void testValidate_TwoCharEndsInDigit_ReturnsLastCharNotLetterFailure() {
+    void testValidate_TwoCharEndsInDigit_ReturnsValid() {
+        // Two-character callsigns ending in digits are now valid
         Callsign callsign = new Callsign("W1");
 
         Callsign.ValidationResult result = callsign.validate();
 
-        assertThat(result.isValid()).isFalse();
-        assertThat(result.failure()).isEqualTo(Callsign.ValidationFailure.LAST_CHAR_NOT_LETTER);
+        assertThat(result.isValid()).isTrue();
     }
 
     @Test
@@ -954,14 +1018,13 @@ class CallsignTest {
     }
 
     @Test
-    void testValidate_InvalidSsid_ShorterCallsign_LastCharNotLetter() {
+    void testValidate_InvalidSsid_ShorterCallsign_IsValid() {
         // -16 is not a valid SSID, so it's kept as part of the callsign
-        // W1A-16 = 6 chars, ends in digit
+        // W1A-16 = 6 chars, ends in digit - now valid since LAST_CHAR_NOT_LETTER removed
         Callsign callsign = new Callsign("W1A-16");
 
         assertThat(callsign.getSsid()).isNull();
-        assertThat(callsign.validate().failure())
-                .isEqualTo(Callsign.ValidationFailure.LAST_CHAR_NOT_LETTER);
+        assertThat(callsign.validate().isValid()).isTrue();
     }
 
     // ===========================================

--- a/src/test/java/io/nextskip/common/util/HamRadioUtilsTest.java
+++ b/src/test/java/io/nextskip/common/util/HamRadioUtilsTest.java
@@ -163,7 +163,7 @@ class HamRadioUtilsTest {
         assertFalse(HamRadioUtils.isValidCallsign("")); // Empty
         assertFalse(HamRadioUtils.isValidCallsign(null)); // Null
         assertFalse(HamRadioUtils.isValidCallsign("Q1ABC")); // Q prefix reserved for Q-codes
-        assertFalse(HamRadioUtils.isValidCallsign("W1AB1")); // Ends with digit (ITU guideline)
+        // Note: W1AB1 is now valid (LAST_CHAR_NOT_LETTER check removed to support SWL callsigns)
     }
 
     @Test

--- a/src/test/java/io/nextskip/spots/internal/enrichment/CallsignEnricherTest.java
+++ b/src/test/java/io/nextskip/spots/internal/enrichment/CallsignEnricherTest.java
@@ -109,16 +109,6 @@ class CallsignEnricherTest {
                 eq("PSKReporter:spotter"));
     }
 
-    @Test
-    void testEnrich_LastCharDigit_RecordsLastCharNotLetterFailure() {
-        Spot spot = createSpot("W1AB1", "W1AW");
-
-        enricher.enrich(spot);
-
-        verify(sampler).recordFailure(eq("W1AB1"), eq(Callsign.ValidationFailure.LAST_CHAR_NOT_LETTER),
-                eq("PSKReporter:spotter"));
-    }
-
     // ===========================================
     // enrich tests - null/blank callsigns
     // ===========================================

--- a/src/test/java/io/nextskip/test/fixtures/CallsignFixtures.java
+++ b/src/test/java/io/nextskip/test/fixtures/CallsignFixtures.java
@@ -44,6 +44,11 @@ public final class CallsignFixtures {
     public static final String LONG_CALLSIGN = "VP2EXYZ";
     public static final String NUMERIC_PREFIX_CALLSIGN = "4X1ABC";
 
+    // SWL (Shortwave Listener) callsigns
+    public static final String NETHERLANDS_SWL = "NL9222";
+    public static final String UK_RSGB_SWL = "RS123456";
+    public static final String GERMANY_SWL = "DE12345";
+
     private CallsignFixtures() {
         // Utility class
     }
@@ -182,5 +187,36 @@ public final class CallsignFixtures {
      */
     public static Callsign numericPrefixCallsign() {
         return new Callsign(NUMERIC_PREFIX_CALLSIGN);
+    }
+
+    /**
+     * Creates a Netherlands SWL callsign (NL9222).
+     *
+     * <p>SWL (Shortwave Listener) callsigns are issued by national amateur
+     * radio societies for receive-only stations. They typically consist of
+     * a country prefix followed by digits.
+     *
+     * @return Netherlands SWL callsign
+     */
+    public static Callsign netherlandsSwlCallsign() {
+        return new Callsign(NETHERLANDS_SWL);
+    }
+
+    /**
+     * Creates a UK RSGB SWL callsign (RS123456).
+     *
+     * @return UK RSGB SWL callsign
+     */
+    public static Callsign ukSwlCallsign() {
+        return new Callsign(UK_RSGB_SWL);
+    }
+
+    /**
+     * Creates a Germany SWL callsign (DE12345).
+     *
+     * @return Germany SWL callsign
+     */
+    public static Callsign germanySwlCallsign() {
+        return new Callsign(GERMANY_SWL);
     }
 }


### PR DESCRIPTION
## Summary

- Remove `LAST_CHAR_NOT_LETTER` validation that was rejecting valid SWL (Shortwave Listener) callsigns like `NL9222`
- Add `isSwl()` method to identify SWL callsigns (heuristic: 2-3 letter prefix + 3-6 digits)
- Add SWL test fixtures for Netherlands, UK RSGB, and Germany formats

## Context

SWL callsigns are issued by national amateur radio societies for receive-only stations. They follow a different format than ITU amateur callsigns (country prefix + digits only), so the previous "last character must be a letter" check incorrectly rejected them.

The `LAST_CHAR_NOT_LETTER` check was already documented as "informational only" with a comment noting "many valid callsigns violate this."

## Test plan

- [x] All existing tests pass
- [x] Quality checks pass (`./gradlew check -x pitest`)
- [x] New `isSwl()` tests cover common SWL formats and edge cases