### PR TITLE
feat(observability): add resilience4j-micrometer for circuit breaker metrics

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,6 +88,7 @@ caffeine = { module = "com.github.ben-manes.caffeine:caffeine" }
 resilience4j-spring-boot3 = { module = "io.github.resilience4j:resilience4j-spring-boot3", version.ref = "resilience4j" }
 resilience4j-circuitbreaker = { module = "io.github.resilience4j:resilience4j-circuitbreaker", version.ref = "resilience4j" }
 resilience4j-retry = { module = "io.github.resilience4j:resilience4j-retry", version.ref = "resilience4j" }
+resilience4j-micrometer = { module = "io.github.resilience4j:resilience4j-micrometer", version.ref = "resilience4j" }
 
 # Jackson XML
 jackson-dataformat-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml" }
@@ -117,7 +118,7 @@ pekko-stream = { module = "org.apache.pekko:pekko-stream_2.13", version.ref = "p
 pekko-stream-testkit = { module = "org.apache.pekko:pekko-stream-testkit_2.13", version.ref = "pekko" }
 
 [bundles]
-resilience4j = ["resilience4j-spring-boot3", "resilience4j-circuitbreaker", "resilience4j-retry"]
+resilience4j = ["resilience4j-spring-boot3", "resilience4j-circuitbreaker", "resilience4j-retry", "resilience4j-micrometer"]
 spring-boot-web = ["spring-boot-starter-web", "spring-boot-starter-cache", "spring-boot-starter-actuator", "spring-boot-starter-validation"]
 vaadin = ["vaadin-spring-boot-starter", "hilla-spring-boot-starter"]
 testcontainers = ["spring-boot-testcontainers", "testcontainers-postgresql", "testcontainers-junit-jupiter"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -157,15 +157,12 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus
+        include: health,info,metrics
       base-path: /actuator
   endpoint:
     health:
       show-details: when-authorized
   metrics:
-    export:
-      prometheus:
-        enabled: true
     data:
       repository:
         autotime:


### PR DESCRIPTION
## Summary

- Add `resilience4j-micrometer` dependency to export circuit breaker and retry metrics
- Remove unused prometheus config (metrics are pushed via OTEL agent, not scraped)

## Metrics Exported

Circuit breaker metrics (per instance: noaa, hamqsl-solar, hamqsl-band, pota, sota, contests):
- `resilience4j_circuitbreaker_state`
- `resilience4j_circuitbreaker_calls_total`
- `resilience4j_circuitbreaker_failure_rate`

Retry metrics:
- `resilience4j_retry_calls_total`

## Test Plan

- [x] `./gradlew build` passes
- [ ] Verify metrics appear in Grafana Cloud after deploy