### PR TITLE
fix(activations): deduplicate by callsign+location for accurate on-air counts

### DIFF
--- a/src/test/java/io/nextskip/common/config/CacheConfigTest.java
+++ b/src/test/java/io/nextskip/common/config/CacheConfigTest.java
@@ -85,8 +85,8 @@ class CacheConfigTest {
 
     @Test
     void testActivationsCache_LoadsFromRepository() {
-        // Given: Repository returns empty list
-        when(activationRepository.findBySpottedAtAfterOrderBySpottedAtDesc(any()))
+        // Given: Repository returns empty list (de-duplicated by callsign+location)
+        when(activationRepository.findLatestPerCallsignAndLocation(any()))
                 .thenReturn(Collections.emptyList());
 
         // When: Create cache and get data
@@ -164,14 +164,14 @@ class CacheConfigTest {
 
     @Test
     void testLoadActivations_ReturnsActivationsFromRepository() {
-        // Given: Repository returns activation entities
+        // Given: Repository returns activation entities (de-duplicated by callsign+location)
         Instant now = Instant.now();
         Activation activation = new Activation(
                 "spot-1", "W1ABC", ActivationType.POTA, 14250.0, "SSB", now, now, 5, "pota",
                 new Park("K-1234", "Test Park", "CA", "US", "CM97", 37.5, -122.1)
         );
         ActivationEntity entity = ActivationEntity.fromDomain(activation);
-        when(activationRepository.findBySpottedAtAfterOrderBySpottedAtDesc(any()))
+        when(activationRepository.findLatestPerCallsignAndLocation(any()))
                 .thenReturn(List.of(entity));
 
         // When: Call loader method directly
@@ -186,8 +186,8 @@ class CacheConfigTest {
 
     @Test
     void testLoadActivations_ReturnsEmptyList() {
-        // Given: Repository returns empty list
-        when(activationRepository.findBySpottedAtAfterOrderBySpottedAtDesc(any()))
+        // Given: Repository returns empty list (de-duplicated by callsign+location)
+        when(activationRepository.findLatestPerCallsignAndLocation(any()))
                 .thenReturn(Collections.emptyList());
 
         // When: Call loader method directly


### PR DESCRIPTION
## Summary

After reducing retention to 30 minutes (PR #284), POTA still showed ~542 "on air" instead of ~100 matching native POTA UI. This was because we counted individual spots rather than unique activators.

- Adds PostgreSQL `DISTINCT ON` query to return only the most recent spot per (callsign, location) pair
- Matches POTA/SOTA native behavior where multiple spots for the same operator at the same location are collapsed into one entry
- If a callsign is spotted at two different locations (parks or peaks), those remain as separate entries

## Test plan

- [x] Integration tests verify de-duplication query behavior
- [x] Unit tests updated to use new query method
- [ ] Verify on production that POTA shows ~100 and SOTA shows ~10-20