### PR TITLE
fix(db): optimize database performance and reduce storage

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,7 +89,7 @@ nextskip:
       persistence-threads: 2       # Thread pool size for DB writes (I/O-bound, safe for single-core)
       persistence-parallelism: 2   # Concurrent batches in mapAsyncUnordered
     persistence:
-      ttl: 24h            # Time-to-live for spots
+      ttl: 6h             # Time-to-live for spots (reduced from 24h for storage optimization)
       cleanup-interval: 1h # How often to run cleanup
     aggregation:
       refresh-interval: 1m    # How often to recalculate band activity

--- a/src/main/resources/db/changelog/migrations/012-drop-unused-indexes.yaml
+++ b/src/main/resources/db/changelog/migrations/012-drop-unused-indexes.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 012-drop-unused-indexes
+      author: arunderwood
+      comment: Remove unused indexes identified in DB health review (January 2026)
+      changes:
+        - dropIndex:
+            indexName: idx_spots_mode_time
+            tableName: spots
+        - dropIndex:
+            indexName: idx_activations_callsign
+            tableName: activations

--- a/src/main/resources/db/changelog/migrations/013-tune-autovacuum.yaml
+++ b/src/main/resources/db/changelog/migrations/013-tune-autovacuum.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: 013-tune-autovacuum
+      author: arunderwood
+      comment: Configure more aggressive autovacuum for small tables (DB health review January 2026)
+      changes:
+        - sql:
+            comment: Reduce autovacuum thresholds for small tables that accumulate dead tuples
+            sql: |
+              -- scheduled_tasks: high churn, low row count - vacuum at 10 dead tuples
+              ALTER TABLE scheduled_tasks SET (autovacuum_vacuum_threshold = 10);
+              ALTER TABLE scheduled_tasks SET (autovacuum_vacuum_scale_factor = 0.05);
+
+              -- contests: moderate churn from refresh cycles - vacuum at 10 dead tuples
+              ALTER TABLE contests SET (autovacuum_vacuum_threshold = 10);
+              ALTER TABLE contests SET (autovacuum_vacuum_scale_factor = 0.1);
+
+              -- activations: moderate churn from POTA/SOTA refreshes - vacuum at 50 dead tuples
+              ALTER TABLE activations SET (autovacuum_vacuum_threshold = 50);
+              ALTER TABLE activations SET (autovacuum_vacuum_scale_factor = 0.1);


### PR DESCRIPTION
## Summary
- Drop unused indexes (`idx_spots_mode_time`, `idx_activations_callsign`) to reclaim ~280MB
- Configure more aggressive autovacuum for small tables with high dead tuple ratios
- Reduce spots TTL from 24h to 6h to reduce storage from ~14GB to ~3.5GB at equilibrium

## Database Health Review Findings
| Metric | Value |
|--------|-------|
| Cache Hit Ratio | 98.72% |
| `idx_spots_mode_time` | 196MB, 0% fetch efficiency |
| `scheduled_tasks` bloat | 84% dead tuples |
| Spots ingestion rate | ~1.4M rows/hour |

## Changes
1. **Migration 012**: Drop unused indexes
2. **Migration 013**: Tune autovacuum thresholds for `scheduled_tasks`, `contests`, `activations`
3. **Config**: Reduce `nextskip.spots.persistence.ttl` from `24h` to `6h`

## Test Plan
- [x] Build compiles successfully
- [ ] Deploy to staging and verify migrations run
- [ ] Monitor spot table size reduction over 6 hours
- [ ] Verify autovacuum clears dead tuples on small tables