### PR TITLE
fix(test): migrate Vitest config from poolOptions to maxWorkers

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,12 +13,7 @@ export default defineConfig({
     css: true,
     // Enable parallel test execution
     pool: 'threads',
-    poolOptions: {
-      threads: {
-        minThreads: 1,
-        maxThreads: Math.max(1, Math.floor(os.cpus().length * 0.75)),
-      },
-    },
+    maxWorkers: Math.max(1, Math.floor(os.cpus().length * 0.75)),
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],


### PR DESCRIPTION
## Summary
- Remove deprecated `poolOptions` configuration removed in Vitest 4
- Migrate to top-level `maxWorkers` option per [migration guide](https://vitest.dev/guide/migration#pool-rework)

Fixes deprecation warning:
```
DEPRECATED  `test.poolOptions` was removed in Vitest 4
```

## Test plan
- [x] `npm run test:run` passes with no deprecation warning
- [x] All 339 tests pass