### PR TITLE
chore(renovate): ignore @rollup/pluginutils (Vaadin-managed)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -97,6 +97,7 @@
         "@types/react",
         "@types/react-dom",
         "@babel/preset-react",
+        "@rollup/pluginutils",
         "vite-plugin-checker",
         "/^@vaadin//",
         "/^workbox-/"


### PR DESCRIPTION
`@rollup/pluginutils` is managed by Vaadin Hilla — it is pinned in the `vaadin.devDependencies` block of `package.json` (`5.3.0`) and re-synced on every `vaadinPrepareFrontend` run.

Renovate PR #573 tried to bump it to `5.4.0`, but Vaadin would revert that on the next frontend build, creating churn. This adds it to the existing **"Vaadin-controlled npm packages - ignore"** rule alongside the other Vaadin-synced packages.

Closes #573.